### PR TITLE
Only load the rubocop tasks when is available

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,11 @@
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
-require 'rubocop/rake_task'
 require_relative 'config/application'
 
 Rails.application.load_tasks
-RuboCop::RakeTask.new(:rubocop)
+
+if Gem.loaded_specs.key?('rubocop')
+  require 'rubocop/rake_task'
+  RuboCop::RakeTask.new(:rubocop)
+end


### PR DESCRIPTION
This is to avoid Heroku try to load Rubocop upon deployment