### PR TITLE
Fixing order of harvest finalization calls to Metrc

### DIFF
--- a/app/services/metrc_service/harvest.rb
+++ b/app/services/metrc_service/harvest.rb
@@ -25,8 +25,8 @@ module MetrcService
     end
 
     def finalize_harvest
-      call_metrc(:finish_harvest, build_harvest_complete_payload)
       call_metrc(:remove_waste, build_remove_waste_payload)
+      call_metrc(:finish_harvest, build_harvest_complete_payload)
     end
 
     def build_manicure_plants_payload(items, _batch)


### PR DESCRIPTION
I realised these should be reversed.