### PR TITLE
Flushing upstream tasks before package create

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -78,4 +78,4 @@ group :lint do
     watch(/.+\.rb$/)
     watch(%r{(?:.+/)?\.rubocop(?:_todo)?\.yml$}) { |m| File.dirname(m[0]) }
   end
-end
+end unless ENV['SKIP_LINT']

--- a/app/jobs/scheduled_job.rb
+++ b/app/jobs/scheduled_job.rb
@@ -1,86 +1,20 @@
 class ScheduledJob < ApplicationJob
-  class SchedulerError < StandardError
-    attr_reader :original
-
-    def initialize(message = nil, original: nil)
-      @original = original
-      super(message)
-    end
-  end
-
-  class RetryableError < SchedulerError; end
-  class TooManyRetriesError < SchedulerError; end
-
   queue_as :default
 
   def perform
+    tasks = get_tasks
     return if tasks.empty?
 
-    tasks.each do |task|
-      run_task(task)
-
-    rescue RetryableError => e
-      Rails.logger.warn("Task #{task.id} failed (attempt ##{task.attempts + 1}) with retryable error, rescheduling...")
-      report_rescheduled(task, e.original)
-      task.reschedule!
-
-    rescue TooManyRetriesError => e
-      report_failed(task, e.original)
-
-    rescue StandardError => e
-      report_failed(task, e)
-    end
+    TaskRunner.run(*tasks)
   end
 
   protected
 
-  def run_task(task)
-    context = build_context(task)
-    vendor_module(task).call(context, task.integration, task)
-  end
+  def get_tasks
+    now = DateTime.now
+    beginning_of_hour = now.beginning_of_hour
+    end_of_hour       = now.end_of_hour
 
-  def tasks
-    @tasks ||= begin
-                 now = DateTime.now
-                 beginning_of_hour = now.beginning_of_hour
-                 end_of_hour       = now.end_of_hour
-
-                 Scheduler.where(run_on: beginning_of_hour..end_of_hour)
-               end
-  end
-
-  def build_context(task)
-    {
-      id: nil,
-      attributes: nil,
-      relationships: {
-        batch: {
-          data: {
-            id: task.batch_id
-          }
-        },
-        facility: {
-          data: {
-            id: task.facility_id
-          }
-        }
-      }
-    }.with_indifferent_access
-  end
-
-  def vendor_module(task)
-    "#{task.integration.vendor.camelize}Service::Batch".constantize
-  end
-
-  def report_rescheduled(task, error)
-    mailer(task, error).report_reschedule_email.deliver_now
-  end
-
-  def report_failed(task, error)
-    mailer(task, error).report_failure_email.deliver_now
-  end
-
-  def mailer(task, error)
-    NotificationMailer.with(task: task, error: error)
+    Scheduler.where(run_on: beginning_of_hour..end_of_hour)
   end
 end

--- a/app/jobs/scheduled_job.rb
+++ b/app/jobs/scheduled_job.rb
@@ -2,15 +2,17 @@ class ScheduledJob < ApplicationJob
   queue_as :default
 
   def perform
-    tasks = get_tasks
+    tasks = find_tasks
     return if tasks.empty?
 
     TaskRunner.run(*tasks)
+  rescue Cannapi::TaskError => e
+    Rails.logger.error("Scheduled job failed: #{e.message}")
   end
 
   protected
 
-  def get_tasks
+  def find_tasks
     now = DateTime.now
     beginning_of_hour = now.beginning_of_hour
     end_of_hour       = now.end_of_hour

--- a/app/models/scheduler.rb
+++ b/app/models/scheduler.rb
@@ -11,13 +11,18 @@ class Scheduler < ApplicationRecord
   validates :run_on, presence: true
   validates :attempts, numericality: { only_integer: true, less_than: MAX_ATTEMPTS }
 
+  # scope :for_today do |timezone|
+  #   now = Time.now.getlocal(timezone)
+  #   where(run_on: now.at_beginning_of_day..now.at_end_of_day)
+  # end
+
   def reschedule!
     update!(
       attempts: attempts + 1,
       run_on: Time.now.utc + RESCHEDULE_DELAY
     )
   rescue ActiveRecord::RecordInvalid
-    raise ScheduledJob::TooManyRetriesError if errors[:attempts].any?
+    raise Cannapi::TooManyRetriesError if errors[:attempts].any?
 
     raise
   end

--- a/app/models/scheduler.rb
+++ b/app/models/scheduler.rb
@@ -11,10 +11,10 @@ class Scheduler < ApplicationRecord
   validates :run_on, presence: true
   validates :attempts, numericality: { only_integer: true, less_than: MAX_ATTEMPTS }
 
-  # scope :for_today do |timezone|
-  #   now = Time.now.getlocal(timezone)
-  #   where(run_on: now.at_beginning_of_day..now.at_end_of_day)
-  # end
+  scope :for_today, ->(timezone) do
+    now = Time.now.getlocal(timezone)
+    where(run_on: now.at_beginning_of_day..now.at_end_of_day)
+  end
 
   def reschedule!
     update!(

--- a/app/runners/task_runner.rb
+++ b/app/runners/task_runner.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+class TaskRunner
+  def self.run(*tasks)
+    tasks.each do |task|
+      new(task).run
+    end
+  end
+
+  def initialize(task)
+    @task = task
+  end
+
+  def run
+    vendor_module.call(build_context, @task.integration, @task)
+  rescue Cannapi::RetryableError => e
+    Rails.logger.warn("Task #{@task.id} failed (attempt ##{@task.attempts + 1}) with retryable error, rescheduling...")
+    report_rescheduled(e.original)
+    @task.reschedule!
+  rescue Cannapi::TooManyRetriesError => e
+    report_failed(e.original)
+  rescue StandardError => e
+    report_failed(e)
+  end
+
+  def build_context
+    {
+      id: nil,
+      attributes: nil,
+      relationships: {
+        batch: { data: { id: @task.batch_id } },
+        facility: { data: { id: @task.facility_id } }
+      }
+    }.with_indifferent_access
+  end
+
+  def vendor_module
+    "#{@task.integration.vendor.camelize}Service::Batch".constantize
+  end
+
+  def report_rescheduled(error)
+    mailer(error).report_reschedule_email.deliver_now
+  end
+
+  def report_failed(error)
+    mailer(error).report_failure_email.deliver_now
+  end
+
+  def mailer(error)
+    NotificationMailer.with(task: @task, error: error)
+  end
+end

--- a/app/services/common/base_service_action.rb
+++ b/app/services/common/base_service_action.rb
@@ -3,6 +3,8 @@ module Common
     class TransactionAlreadyExecuted < StandardError; end
     class ServiceActionFailure < StandardError; end
 
+    DEFAULT_RUN_MODE = :later
+
     def self.call(*args, &block)
       instance = new(*args, &block)
       instance.run
@@ -10,6 +12,11 @@ module Common
       instance.result
     rescue ServiceActionFailure
       instance.result
+    end
+
+    def self.run_mode(mode = nil)
+      @mode = mode if mode.present?
+      @mode || DEFAULT_RUN_MODE
     end
 
     attr_accessor :result, :integration, :transaction

--- a/app/services/common/base_service_action.rb
+++ b/app/services/common/base_service_action.rb
@@ -77,7 +77,7 @@ module Common
     end
 
     def requeue!(exception: nil)
-      raise ScheduledJob::RetryableError.new(exception&.message, original: exception)
+      raise Cannapi::RetryableError.new(exception&.message, original: exception)
     end
 
     def log(msg, level = :info)

--- a/app/services/integration_service.rb
+++ b/app/services/integration_service.rb
@@ -4,30 +4,49 @@ class IntegrationService < ApplicationService
   end
 
   def call
-    facility_id = @ctx.dig('relationships', 'facility', 'data', 'id')
     # Look up for active integrations
     integrations = Integration.active.where(facility_id: facility_id)
-
     raise 'No integrations for this facility' unless integrations.size.positive?
 
     integrations.each do |integration|
-      now = Time.now.getlocal(integration.timezone)
+      ref_time = Time.now.getlocal(integration.timezone)
 
-      if now.hour >= integration.eod.hour
-        VendorJob.perform_later(@ctx, integration)
+      if integration.vendor_module.run_now?(@ctx, integration, ref_time)
+        execute_job(integration)
       else
-        batch_id = @ctx.dig('relationships', 'batch', 'data', 'id')
-        later = now.at_beginning_of_day + integration.eod.hour.hours
-
-        exists = Scheduler.where(facility_id: facility_id, batch_id: batch_id, run_on: now.at_beginning_of_day..now.at_end_of_day)
-
-        next if exists.size.positive?
-
-        Scheduler.create(integration: integration,
-                         facility_id: facility_id,
-                         batch_id: batch_id,
-                         run_on: later.utc)
+        schedule_job(integration, ref_time)
       end
     end
+  end
+
+  def execute_job(integration)
+    VendorJob.perform_later(@ctx, integration)
+  end
+
+  def schedule_job(integration, ref_time)
+    exists = Scheduler.where(
+      facility_id: facility_id,
+      batch_id: batch_id,
+      run_on: ref_time.at_beginning_of_day..ref_time.at_end_of_day
+    )
+
+    return if exists.size.positive?
+
+    later = ref_time.at_beginning_of_day + integration.eod.hour.hours
+
+    Scheduler.create(
+      integration: integration,
+      facility_id: facility_id,
+      batch_id: batch_id,
+      run_on: later.utc
+    )
+  end
+
+  def facility_id
+    @facility_id ||= @ctx.dig('relationships', 'facility', 'data', 'id')
+  end
+
+  def batch_id
+    @batch_id ||= @ctx.dig('relationships', 'batch', 'data', 'id')
   end
 end

--- a/app/services/metrc_service.rb
+++ b/app/services/metrc_service.rb
@@ -28,11 +28,15 @@ module MetrcService
     'Pound' => 'Pounds'
   }.freeze
 
-  module_function
-
   def perform_action(ctx, integration, task = nil)
     Lookup.new(ctx, integration, task).perform_action
   end
+
+  def run_now?(ctx, integration, ref_time)
+    ref_time.hour >= integration.eod.hour || Lookup.new(ctx, integration).run_mode == :now
+  end
+
+  module_function :perform_action, :run_now?
 
   class Lookup
     def initialize(ctx, integration, task = nil)
@@ -42,6 +46,7 @@ module MetrcService
     end
 
     delegate :seeding_unit, to: :batch
+    delegate :run_mode, to: :module_for_completion
 
     def perform_action
       handler = module_for_completion

--- a/app/services/metrc_service.rb
+++ b/app/services/metrc_service.rb
@@ -4,6 +4,7 @@ module MetrcService
   class InvalidOperation < StandardError; end
   class InvalidAttributes < StandardError; end
   class DataMismatch < StandardError; end
+  class UpstreamProcessingError < StandardError; end
 
   CROP = 'Cannabis'.freeze
 

--- a/app/services/metrc_service.rb
+++ b/app/services/metrc_service.rb
@@ -32,8 +32,8 @@ module MetrcService
     Lookup.new(ctx, integration, task).perform_action
   end
 
-  def run_now?(ctx, integration, ref_time)
-    ref_time.hour >= integration.eod.hour || Lookup.new(ctx, integration).run_mode == :now
+  def run_now?(ctx, integration)
+    Lookup.new(ctx, integration).run_mode == :now
   end
 
   module_function :perform_action, :run_now?

--- a/app/services/metrc_service/batch.rb
+++ b/app/services/metrc_service/batch.rb
@@ -12,7 +12,7 @@ module MetrcService
     def after; end
 
     def call
-      completions.each do |completion|
+      transactions = completions.map do |completion|
         ctx = {
           id: completion.id,
           type: :completions,
@@ -25,8 +25,8 @@ module MetrcService
 
       @task.delete
 
-      # explicitly return nil
-      nil
+      # a stub tranasction to represent the state of the batched transactions
+      Transaction.new(success: transactions.all?(&:success?))
     end
 
     def batch
@@ -44,7 +44,7 @@ module MetrcService
       return if completions.size.positive?
 
       @task.delete
-      raise InvalidOperation, "Completions where already performed. Batch ID #{@batch_id}"
+      raise TransactionAlreadyExecuted, 'batch already processed'
     end
 
     def completions

--- a/app/services/metrc_service/batch.rb
+++ b/app/services/metrc_service/batch.rb
@@ -12,7 +12,7 @@ module MetrcService
     def after; end
 
     def call
-      transactions = completions.map do |completion|
+      transactions = completions.each_with_object([]) do |completion, arr|
         ctx = {
           id: completion.id,
           type: :completions,
@@ -20,13 +20,17 @@ module MetrcService
           relationships: @relationships
         }.with_indifferent_access
 
-        MetrcService.perform_action(ctx, @integration, @task)
+        arr << MetrcService.perform_action(ctx, @integration, @task)
+
+        # halt if the last action failed
+        break arr unless arr.last&.success?
       end
 
-      @task.delete
-
       # a stub tranasction to represent the state of the batched transactions
-      Transaction.new(success: transactions.all?(&:success?))
+      result = Transaction.new(success: transactions.all?(&:success?))
+      @task.delete if result.success?
+
+      result
     end
 
     def batch

--- a/app/services/metrc_service/package/base.rb
+++ b/app/services/metrc_service/package/base.rb
@@ -2,7 +2,7 @@ module MetrcService
   module Package
     class Base < MetrcService::Base
       def validate_seeding_unit!
-        return if seeding_unit.name =~ /^(Testing )?Package$/
+        return if seeding_unit.name.match?(/^(Testing )?Package$/)
 
         raise InvalidBatch, "Failed: Seeding unit is not valid for Package completions: #{seeding_unit.name}. " \
           "Batch ID #{@batch_id}, completion ID #{@completion_id}"

--- a/app/services/metrc_service/package/start.rb
+++ b/app/services/metrc_service/package/start.rb
@@ -1,6 +1,8 @@
 module MetrcService
   module Package
     class Start < MetrcService::Package::Base
+      run_mode :now
+
       def call
         create_package
         # finish_harvests

--- a/app/services/metrc_service/package/start.rb
+++ b/app/services/metrc_service/package/start.rb
@@ -4,6 +4,8 @@ module MetrcService
       run_mode :now
 
       def call
+        flush_upstream_tasks
+
         create_package
         # finish_harvests
 
@@ -14,6 +16,25 @@ module MetrcService
 
       def transaction
         @transaction ||= get_transaction(:start_package_batch)
+      end
+
+      def flush_upstream_tasks
+        consume_completions.each do |consume|
+          source_batch_id = consume.context.dig('source_batch', 'id')
+          tasks = upstream_tasks(source_batch_id)
+          next if tasks.empty?
+
+          TaskRunner.run(*tasks)
+        end
+      rescue Cannapi::TaskError => e
+        raise UpstreamProcessingError, "Failed to process upstream tasks: #{e.message}"
+      end
+
+      def upstream_tasks(source_batch_id)
+        @integration
+          .schedulers
+          .for_today(@integration.timezone)
+          .where(batch_id: source_batch_id, facility_id: @facility_id)
       end
 
       def finish_harvests

--- a/config/application.rb
+++ b/config/application.rb
@@ -39,4 +39,16 @@ module Cannapi
 
     config.web_console.whiny_requests = false if ENV['WAIT_HOSTS'] # We're running on docker-compose!
   end
+
+  class TaskError < StandardError
+    attr_reader :original
+
+    def initialize(message = nil, original: nil)
+      @original = original
+      super(message)
+    end
+  end
+
+  class RetryableError < TaskError; end
+  class TooManyRetriesError < TaskError; end
 end

--- a/spec/factories/account_factory.rb
+++ b/spec/factories/account_factory.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :account do
-    artemis_id { SecureRandom.uuid }
+    sequence(:artemis_id) { |n| n }
     name { Faker::Name.name }
     access_token { Faker::Alphanumeric.unique.alphanumeric(number: 10) }
     refresh_token { Faker::Alphanumeric.unique.alphanumeric(number: 10) }

--- a/spec/factories/transaction_factory.rb
+++ b/spec/factories/transaction_factory.rb
@@ -22,6 +22,10 @@ FactoryBot.define do
       type { :discard_batch }
     end
 
+    trait :start do
+      type { :start_batch }
+    end
+
     trait :harvest do
       type { :harvest_batch }
     end

--- a/spec/jobs/scheduled_job_spec.rb
+++ b/spec/jobs/scheduled_job_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe ScheduledJob, type: :job do
   end
 
   context 'with a scheduled task' do
+    let(:successful_transaction) { create(:transaction, :start, :successful) }
     let(:task) { create(:task, integration: integration, facility_id: integration.facility_id, batch_id: 3000, run_on: now) }
 
     it 'calls the vendor module' do
@@ -44,7 +45,7 @@ RSpec.describe ScheduledJob, type: :job do
       expect(Scheduler).to receive(:where).with(hash_including(run_on: beginning_of_hour..end_of_hour))
                                           .and_return([task])
 
-      service_action = double(:action, run: true, result: true)
+      service_action = double(:action, run: true, result: successful_transaction)
       expect(MetrcService::Batch).to receive(:new).and_return(service_action)
 
       perform_enqueued_jobs { subject }

--- a/spec/jobs/scheduled_job_spec.rb
+++ b/spec/jobs/scheduled_job_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe ScheduledJob, type: :job do
     end
 
     context 'that can be rescheduled' do
-      let(:raised_error) { ScheduledJob::RetryableError.new('something went wrong', original: original_error) }
+      let(:raised_error) { Cannapi::RetryableError.new('something went wrong', original: original_error) }
 
       before do
         expect(mailer_with_params)
@@ -83,7 +83,7 @@ RSpec.describe ScheduledJob, type: :job do
     end
 
     context 'that can NOT be rescheduled due to too many retries' do
-      let(:raised_error) { ScheduledJob::TooManyRetriesError.new('something went wrong too many times', original: original_error) }
+      let(:raised_error) { Cannapi::TooManyRetriesError.new('something went wrong too many times', original: original_error) }
 
       before do
         expect(mailer_with_params)

--- a/spec/models/scheduler_spec.rb
+++ b/spec/models/scheduler_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Scheduler, type: :model do
       end
 
       it 'should raise an error' do
-        expect { subject.reschedule! }.to raise_error(ScheduledJob::TooManyRetriesError)
+        expect { subject.reschedule! }.to raise_error(Cannapi::TooManyRetriesError)
       end
     end
   end

--- a/spec/runners/task_runner_spec.rb
+++ b/spec/runners/task_runner_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe(TaskRunner) do
+  def load_response_json(path)
+    File.read("spec/support/data/#{path}.json")
+  end
+
+  describe '.run' do
+    subject { described_class.run(task) }
+
+    before do
+      stub_request(:get, "https://portal.artemisag.com/api/v3/facilities/#{facility_id}")
+        .to_return(status: 200, body: load_response_json('task_runner/facility'))
+
+      stub_request(:get, "https://portal.artemisag.com/api/v3/facilities/#{facility_id}/batches/#{batch_id}?include=zone,barcodes,completions,custom_data,seeding_unit,harvest_unit,sub_zone")
+        .to_return(status: 200, body: load_response_json('task_runner/batch'))
+
+      expect(MetrcService::Plant::Start)
+        .to receive(:call)
+        .and_return(successful_transaction)
+    end
+
+    let(:batch_id) { 374 }
+    let(:facility_id) { 2 }
+    let(:task) { create(:task, batch_id: batch_id, facility_id: facility_id) }
+    let(:successful_transaction) { create(:transaction, :start, :successful) }
+
+    it { is_expected.to be_an(Array) }
+
+    it 'returns a successful transaction' do
+      expect(subject.all?(&:success?)).to eq(true)
+    end
+  end
+end

--- a/spec/services/metrc_service/base_spec.rb
+++ b/spec/services/metrc_service/base_spec.rb
@@ -3,6 +3,11 @@ require 'rails_helper'
 RSpec.describe MetrcService::Base do
   let(:integration) { create(:integration, state: :ca) }
 
+  context '#run_mode' do
+    subject { described_class.run_mode }
+    it { is_expected.to eq(:later) }
+  end
+
   context 'holds the basic attributes' do
     subject { MetrcService::Base.new({}, integration) }
 

--- a/spec/services/metrc_service/base_spec.rb
+++ b/spec/services/metrc_service/base_spec.rb
@@ -348,7 +348,7 @@ RSpec.describe MetrcService::Base do
       end
 
       it 'should raise an error' do
-        expect { call }.to raise_error(ScheduledJob::RetryableError)
+        expect { call }.to raise_error(Cannapi::RetryableError)
       end
     end
   end

--- a/spec/services/metrc_service/package/start_spec.rb
+++ b/spec/services/metrc_service/package/start_spec.rb
@@ -121,6 +121,7 @@ RSpec.describe MetrcService::Package::Start do
         ]
       end
 
+      let(:crop_batch_id) { 15 }
       let(:testing) { raise 'override in subcontext' }
 
       before do
@@ -131,9 +132,9 @@ RSpec.describe MetrcService::Package::Start do
           .to_return(body: load_response_json("api/package/batch#{testing ? '-testing' : ''}"))
 
         stub_request(:get, "#{ENV['ARTEMIS_BASE_URI']}/api/v3/facilities/#{facility_id}/completions?filter[crop_batch_ids][]=#{batch_id}")
-          .to_return(body: { data: [{ id: '90210', type: 'completions', attributes: { id: 90210, action_type: 'start', parent_id: 90209 } }, { id: '90211', type: 'completions', attributes: { id: 90211, action_type: 'consume', parent_id: 90209, context: { source_batch: { id: 15 } }, options: { resource_unit_id: 26, batch_resource_id: 123, consumed_quantity: 50, requested_quantity: 10 } } }] }.to_json)
+          .to_return(body: { data: [{ id: '90210', type: 'completions', attributes: { id: 90210, action_type: 'start', parent_id: 90209 } }, { id: '90211', type: 'completions', attributes: { id: 90211, action_type: 'consume', parent_id: 90209, context: { source_batch: { id: crop_batch_id } }, options: { resource_unit_id: 26, batch_resource_id: 123, consumed_quantity: 50, requested_quantity: 10 } } }] }.to_json)
 
-        stub_request(:get, "#{ENV['ARTEMIS_BASE_URI']}/api/v3/facilities/#{facility_id}/batches/15")
+        stub_request(:get, "#{ENV['ARTEMIS_BASE_URI']}/api/v3/facilities/#{facility_id}/batches/#{crop_batch_id}")
           .to_return(body: load_response_json('api/package/crop-batch'))
 
         stub_request(:get, "#{ENV['ARTEMIS_BASE_URI']}/api/v3/facilities/#{facility_id}/resource_units/26")
@@ -159,8 +160,40 @@ RSpec.describe MetrcService::Package::Start do
 
       context 'standard package' do
         let(:testing) { false }
+        let(:upstream_transaction) { create(:transaction, :start, :successful) }
+
         it { is_expected.to eq(transaction) }
         it { is_expected.to be_success }
+
+        context 'when upstream tasks are not yet processed' do
+          before do
+            run_on = Time.parse("#{Time.now.localtime(integration.timezone).strftime('%F')}T#{integration.eod}#{integration.timezone}")
+
+            create(
+              :task,
+              integration: integration,
+              batch_id: crop_batch_id,
+              facility_id: facility_id,
+              run_on: run_on
+            )
+
+            stub_request(:get, "https://portal.artemisag.com/api/v3/facilities/2/batches/15?include=zone,barcodes,completions,custom_data,seeding_unit,harvest_unit,sub_zone")
+              .to_return(body: load_response_json('api/package/crop-batch'))
+
+            expect(MetrcService::Plant::Start)
+              .to receive(:call)
+              .and_return(upstream_transaction)
+          end
+
+          context 'when upstream tasks succeed' do
+            it { is_expected.to be_success }
+          end
+
+          context 'when upstream tasks fail' do
+            let(:upstream_transaction) { create(:transaction, :start, :unsuccessful) }
+            it { is_expected.not_to be_success }
+          end
+        end
       end
 
       context 'testing package' do

--- a/spec/services/metrc_service/package/start_spec.rb
+++ b/spec/services/metrc_service/package/start_spec.rb
@@ -8,6 +8,11 @@ RSpec.describe MetrcService::Package::Start do
     File.read("spec/support/data/#{path}.json")
   end
 
+  context '#run_mode' do
+    subject { described_class.run_mode }
+    it { is_expected.to eq(:now) }
+  end
+
   let(:integration) { create(:integration, state: 'ca') }
   let(:facility_id) { 2 }
   let(:batch_id) { 374 }

--- a/spec/services/metrc_service_spec.rb
+++ b/spec/services/metrc_service_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe MetrcService do
         .and_return(target_module)
     end
 
-    subject { described_class.run_now?(ctx, integration, ref_time) }
+    subject { described_class.run_now?(ctx, integration) }
 
     context 'when it should execute immediately' do
       let(:target_module) do

--- a/spec/services/metrc_service_spec.rb
+++ b/spec/services/metrc_service_spec.rb
@@ -115,4 +115,46 @@ RSpec.describe MetrcService do
       end
     end
   end
+
+  context '#run_now?' do
+    let(:integration) { create(:integration, eod: "#{Time.now.hour}:00") }
+    let(:ctx) { double(:ctx) }
+    let(:ref_time) { Time.now.localtime(integration.timezone) }
+
+    before do
+      expect_any_instance_of(MetrcService::Lookup)
+        .to receive(:module_for_completion)
+        .and_return(target_module)
+    end
+
+    subject { described_class.run_now?(ctx, integration, ref_time) }
+
+    context 'when it should execute immediately' do
+      let(:target_module) do
+        Class.new(MetrcService::Base) do
+          run_mode :now
+        end
+      end
+
+      it { is_expected.to eq(true) }
+    end
+
+    context 'when it should schedule execution for later' do
+      context 'by default' do
+        let(:target_module) { Class.new(MetrcService::Base) }
+
+        it { is_expected.to eq(false) }
+      end
+
+      context 'by design' do
+        let(:target_module) do
+          Class.new(MetrcService::Base) do
+            run_mode :later
+          end
+        end
+
+        it { is_expected.to eq(false) }
+      end
+    end
+  end
 end

--- a/spec/support/data/api/package/crop-batch.json
+++ b/spec/support/data/api/package/crop-batch.json
@@ -53,8 +53,9 @@
         }
       },
       "seeding_unit": {
-        "meta": {
-          "included": false
+        "data": {
+          "id": "8",
+          "type": "seeding_units"
         }
       },
       "sub_zone": {
@@ -71,6 +72,177 @@
     },
     "type": "batches"
   },
+  "included": [
+    {
+      "attributes": {
+        "id": 8,
+        "item_tracking_method": "preprinted",
+        "name": "Plant (Barcoded)",
+        "secondary_display_active": false,
+        "secondary_display_capacity": 0
+      },
+      "id": "8",
+      "type": "seeding_units"
+    },
+    {
+      "attributes": {
+        "created_at": "2020-02-07T20:52:32.610Z",
+        "facility_id": 2,
+        "id": 20,
+        "name": "Mother Room Prop",
+        "position": null,
+        "seeding_unit": {
+          "id": 8,
+          "name": "Plant (Barcoded)",
+          "secondary_display_active": null,
+          "secondary_display_capacity": 0,
+          "zones": [
+            {
+              "id": 16,
+              "name": "F3 - Inside",
+              "seeding_unit_id": 8,
+              "slug": "f3---inside",
+              "sub_zones": [],
+              "zone_type": null
+            },
+            {
+              "id": 13,
+              "name": "F4 - Outside",
+              "seeding_unit_id": 8,
+              "slug": "f4---outside",
+              "sub_zones": [],
+              "zone_type": null
+            },
+            {
+              "id": 12,
+              "name": "F5 - Zone 1",
+              "seeding_unit_id": 8,
+              "slug": "f5---zone-1",
+              "sub_zones": [],
+              "zone_type": null
+            },
+            {
+              "id": 11,
+              "name": "F5 - Zone 2",
+              "seeding_unit_id": 8,
+              "slug": "f5---zone-2",
+              "sub_zones": [],
+              "zone_type": null
+            },
+            {
+              "id": 10,
+              "name": "F5 - Zone 3",
+              "seeding_unit_id": 8,
+              "slug": "f5---zone-3",
+              "sub_zones": [],
+              "zone_type": null
+            },
+            {
+              "id": 9,
+              "name": "F5 - Zone 4",
+              "seeding_unit_id": 8,
+              "slug": "f5---zone-4",
+              "sub_zones": [],
+              "zone_type": null
+            },
+            {
+              "id": 8,
+              "name": "F5 - Zone 5",
+              "seeding_unit_id": 8,
+              "slug": "f5---zone-5",
+              "sub_zones": [],
+              "zone_type": null
+            },
+            {
+              "id": 15,
+              "name": "F6 - Zone 1",
+              "seeding_unit_id": 8,
+              "slug": "f6---zone-1",
+              "sub_zones": [],
+              "zone_type": null
+            },
+            {
+              "id": 14,
+              "name": "F6 - Zone 4",
+              "seeding_unit_id": 8,
+              "slug": "f6---zone-4",
+              "sub_zones": [],
+              "zone_type": null
+            },
+            {
+              "id": 7,
+              "name": "F7 - L",
+              "seeding_unit_id": 8,
+              "slug": "f7---l",
+              "sub_zones": [],
+              "zone_type": null
+            },
+            {
+              "id": 22,
+              "name": "Mother Room",
+              "seeding_unit_id": 8,
+              "slug": "mother-room",
+              "sub_zones": [],
+              "zone_type": null
+            },
+            {
+              "id": 20,
+              "name": "Mother Room Prop",
+              "seeding_unit_id": 8,
+              "slug": "mother-room-prop",
+              "sub_zones": [],
+              "zone_type": null
+            },
+            {
+              "id": 21,
+              "name": "Propagation",
+              "seeding_unit_id": 8,
+              "slug": "propagation",
+              "sub_zones": [],
+              "zone_type": null
+            },
+            {
+              "id": 23,
+              "name": "VA - Zone 1",
+              "seeding_unit_id": 8,
+              "slug": "va---zone-1",
+              "sub_zones": [],
+              "zone_type": null
+            },
+            {
+              "id": 24,
+              "name": "VD - Top",
+              "seeding_unit_id": 8,
+              "slug": "vd---top",
+              "sub_zones": [],
+              "zone_type": null
+            }
+          ]
+        },
+        "seeding_unit_capacity": 150,
+        "size": 91.0,
+        "slug": "mother-room-prop",
+        "status": "active",
+        "system": null,
+        "updated_at": "2020-02-07T20:52:32.610Z",
+        "zone_type": null
+      },
+      "id": "20",
+      "relationships": {
+        "seeding_unit": {
+          "meta": {
+            "included": false
+          }
+        },
+        "sub_zones": {
+          "meta": {
+            "included": false
+          }
+        }
+      },
+      "type": "zones"
+    }
+  ],
   "jsonapi": {
     "version": "1.0"
   }

--- a/spec/support/data/task_runner/batch.json
+++ b/spec/support/data/task_runner/batch.json
@@ -1,0 +1,161 @@
+{
+  "data": {
+    "attributes": {
+      "arbitrary_id": "Feb24-5th-Ele-Can-2",
+      "completed_at": null,
+      "crop": "Cannabis",
+      "crop_variety": "5th Element",
+      "expected_harvest_at": "2020-02-24",
+      "facility_id": 2,
+      "harvest_quantity": null,
+      "harvested_at": null,
+      "id": 374,
+      "quantity": 1.0,
+      "seeded_at": "2020-02-24",
+      "start_type": "seed",
+      "zone_name": "Warehouse"
+    },
+    "id": "374",
+    "relationships": {
+      "barcodes": {
+        "data": [
+          {
+            "id": "asdfasdfasdfasdf123123123",
+            "type": "barcodes"
+          }
+        ]
+      },
+      "completions": {
+        "data": [
+          {
+            "id": "987",
+            "type": "completions"
+          }
+        ] 
+      },
+      "custom_data": {
+        "data": []
+      },
+      "discards": {
+        "meta": {
+          "included": false
+        }
+      },
+      "harvest_unit": {
+        "data": null
+      },
+      "harvests": {
+        "meta": {
+          "included": false
+        }
+      },
+      "items": {
+        "meta": {
+          "included": false
+        }
+      },
+      "seeding_unit": {
+        "data": {
+          "id": "11",
+          "type": "seeding_units"
+        }
+      },
+      "sub_zone": {
+        "data": {
+          "id": null,
+          "type": "sub_zones"
+        }
+      },
+      "zone": {
+        "data": {
+          "id": 25,
+          "type": "zones"
+        }
+      }
+    },
+    "type": "batches"
+  },
+  "included": [
+    {
+      "attributes": {
+        "id": "asdfasdfasdfasdf123123123"
+      },
+      "id": "asdfasdfasdfasdf123123123",
+      "relationships": {
+        "target": {
+          "meta": {
+            "included": false
+          }
+        }
+      },
+      "type": "barcodes"
+    },
+    {
+      "attributes": {
+        "id": 11,
+        "item_tracking_method": "none",
+        "name": "Plant (barcoded)",
+        "secondary_display_active": false,
+        "secondary_display_capacity": 0
+      },
+      "id": "11",
+      "type": "seeding_units"
+    },
+    {
+      "attributes": {
+        "created_at": "2020-02-07T20:52:33.732Z",
+        "facility_id": 2,
+        "id": 25,
+        "name": "Warehouse",
+        "position": null,
+        "seeding_unit": {
+          "id": 11,
+          "name": "Plant (barcoded)",
+          "secondary_display_active": null,
+          "secondary_display_capacity": 0,
+          "zones": [
+            {
+              "id": 25,
+              "name": "Warehouse",
+              "seeding_unit_id": 11,
+              "slug": "warehouse",
+              "sub_zones": [],
+              "zone_type": null
+            }
+          ]
+        },
+        "seeding_unit_capacity": 1200,
+        "size": 64.0,
+        "slug": "warehouse",
+        "status": "active",
+        "system": null,
+        "updated_at": "2020-02-07T20:52:33.732Z",
+        "zone_type": null
+      },
+      "id": "25",
+      "relationships": {
+        "seeding_unit": {
+          "meta": {
+            "included": false
+          }
+        },
+        "sub_zones": {
+          "meta": {
+            "included": false
+          }
+        }
+      },
+      "type": "zones"
+    },
+    {
+      "attributes": {
+        "action_type": "start"
+      },
+      "id": "987",
+      "type": "completions"
+    }
+  ],
+  "jsonapi": {
+    "version": "1.0"
+  }
+}

--- a/spec/support/data/task_runner/facility.json
+++ b/spec/support/data/task_runner/facility.json
@@ -1,0 +1,60 @@
+{
+  "data": {
+    "attributes": {
+      "city": "Muy",
+      "country_code": "JM",
+      "crops_columns": [
+        "days_since_seeding",
+        "harvest_date",
+        "harvest_zone",
+        "identifier",
+        "initial_zone",
+        "next_move_date",
+        "planned_harvest_date",
+        "seed_quantity",
+        "quantity",
+        "timeline",
+        "zone",
+        "estimated_labor_hours"
+      ],
+      "facility_type": "greenhouse",
+      "id": 2,
+      "name": "Cannademo West",
+      "organization_id": 3,
+      "postal_code": "15701-4629",
+      "size": 3887,
+      "size_type": "sqft",
+      "slug": "cannademo-west",
+      "state": "KY",
+      "status": "active",
+      "time_zone": "Eastern Time (US & Canada)"
+    },
+    "id": "2",
+    "relationships": {
+      "metrics": {
+        "meta": {
+          "included": false
+        }
+      },
+      "resource_units": {
+        "meta": {
+          "included": false
+        }
+      },
+      "sensors": {
+        "meta": {
+          "included": false
+        }
+      },
+      "users": {
+        "meta": {
+          "included": false
+        }
+      }
+    },
+    "type": "facilities"
+  },
+  "jsonapi": {
+    "version": "1.0"
+  }
+}


### PR DESCRIPTION
- Task execution logic and error handling moved into `TaskRunner`
- `TaskRunner` used to run tasks in multiple contexts (scheduled job calls, upstream flushing)
- Service modules can specify when/how they should run using the `run_mode` macro defined in `BaseServiceAction`
