### PR TITLE
Remove hardcoded default plant destroy reason

### DIFF
--- a/app/services/metrc_service/plant/discard.rb
+++ b/app/services/metrc_service/plant/discard.rb
@@ -13,7 +13,8 @@ module MetrcService
       private
 
       def plant_state
-        @plant_state ||= seeding_unit.item_tracking_method.nil? ? 'immature' : 'mature'
+        tracking_method = seeding_unit.item_tracking_method
+        @plant_state ||= [nil, 'none'].include?(tracking_method) ? 'immature' : 'mature'
       end
 
       def transaction
@@ -21,9 +22,7 @@ module MetrcService
       end
 
       def discard
-        @artemis.facility(@facility_id)
-                .batch(batch.id)
-                .discard(@relationships.dig('action_result', 'data', 'id'))
+        batch.discard(@relationships.dig('action_result', 'data', 'id'))
       end
 
       def build_immature_payload(discard, batch)

--- a/app/services/metrc_service/plant/discard.rb
+++ b/app/services/metrc_service/plant/discard.rb
@@ -69,10 +69,9 @@ module MetrcService
       def reason_note(discard)
         reason_description = discard.attributes['reason_description']
         reason_type = discard.attributes['reason_type']
-        reason_note = 'Does not meet internal QC'
         reason_note = "#{reason_type.capitalize}: #{reason_description}. #{@attributes.dig('options', 'note_content')}" if reason_type && reason_description
 
-        reason_note
+        reason_note || ''
       end
     end
   end

--- a/app/services/metrc_service/plant/discard.rb
+++ b/app/services/metrc_service/plant/discard.rb
@@ -1,6 +1,8 @@
 module MetrcService
   module Plant
     class Discard < MetrcService::Base
+      NOT_SPECIFIED = 'Not Specified'.freeze
+
       def call
         payload = send("build_#{plant_state}_payload", discard, batch)
         action = plant_state == 'immature' ? :destroy_plant_batches : :destroy_plants
@@ -70,7 +72,7 @@ module MetrcService
         reason_type = discard.attributes['reason_type']
         reason_note = "#{reason_type.capitalize}: #{reason_description}. #{@attributes.dig('options', 'note_content')}" if reason_type && reason_description
 
-        reason_note || ''
+        reason_note || NOT_SPECIFIED
       end
     end
   end

--- a/spec/services/metrc_service/plant/discard_spec.rb
+++ b/spec/services/metrc_service/plant/discard_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe MetrcService::Plant::Discard do
 
         stub_request(:post, 'https://sandbox-api-md.metrc.com/plants/v1/destroyplants?licenseNumber=LIC-0001')
           .with(
-            body: [{ Id: nil, Label: '1A4FF010000002200000105', ReasonNote: 'Does not meet internal QC', ActualDate: '2019-10-25T00:00:00.000Z' }, { Id: nil, Label: '1A4FF010000002200000104', ReasonNote: 'Does not meet internal QC', ActualDate: '2019-10-25T00:00:00.000Z' }, { Id: nil, Label: '1A4FF010000002200000103', ReasonNote: 'Does not meet internal QC', ActualDate: '2019-10-25T00:00:00.000Z' }].to_json,
+            body: [{ Id: nil, Label: '1A4FF010000002200000105', ReasonNote: '', ActualDate: '2019-10-25T00:00:00.000Z' }, { Id: nil, Label: '1A4FF010000002200000104', ReasonNote: '', ActualDate: '2019-10-25T00:00:00.000Z' }, { Id: nil, Label: '1A4FF010000002200000103', ReasonNote: '', ActualDate: '2019-10-25T00:00:00.000Z' }].to_json,
             basic_auth: [METRC_API_KEY, integration.secret]
           )
           .to_return(status: 200, body: '', headers: {})
@@ -136,9 +136,7 @@ RSpec.describe MetrcService::Plant::Discard do
           .not_to receive(:get_transaction)
       end
 
-      # FIXME
-      # it { is_expected.to be_a(Transaction) }
-      # it { is_expected.to be_success }
+      it { is_expected.to be_success }
     end
 
     describe 'on a partial discard' do
@@ -182,15 +180,13 @@ RSpec.describe MetrcService::Plant::Discard do
 
         stub_request(:post, 'https://sandbox-api-md.metrc.com/plantbatches/v1/destroy?licenseNumber=LIC-0001')
           .with(
-            body: [{ PlantBatch: 'Oct1-Ban-Spl-Can', Count: 5, ReasonNote: 'Does not meet internal QC', ActualDate: '2019-10-25T00:00:00.000Z' }].to_json,
+            body: [{ PlantBatch: 'Oct1-Ban-Spl-Can', Count: 5, ReasonNote: '', ActualDate: '2019-10-25T00:00:00.000Z' }].to_json,
             basic_auth: [METRC_API_KEY, integration.secret]
           )
           .to_return(status: 200, body: '', headers: {})
       end
 
-      # FIXME
-      # it { is_expected.to be_a(Transaction) }
-      # it { is_expected.to be_success }
+      it { is_expected.to be_success }
     end
   end
 

--- a/spec/services/metrc_service/plant/discard_spec.rb
+++ b/spec/services/metrc_service/plant/discard_spec.rb
@@ -210,7 +210,7 @@ RSpec.describe MetrcService::Plant::Discard do
       expect(payload.first).to eq(
         PlantBatch: 'Oct1-Ban-Spl-Can',
         Count: 1,
-        ReasonNote: 'Does not meet internal QC',
+        ReasonNote: '',
         ActualDate: now
       )
     end
@@ -249,7 +249,7 @@ RSpec.describe MetrcService::Plant::Discard do
         expect(payload.first).to eq(
           Id: nil,
           Label: '1A4FF01000000220000010',
-          ReasonNote: 'Does not meet internal QC',
+          ReasonNote: '',
           ActualDate: now
         )
       end
@@ -263,7 +263,7 @@ RSpec.describe MetrcService::Plant::Discard do
         instance = described_class.new(ctx, integration)
         note = instance.send :reason_note, discard
 
-        expect(note).to eq 'Does not meet internal QC'
+        expect(note).to eq ''
       end
     end
 
@@ -275,7 +275,7 @@ RSpec.describe MetrcService::Plant::Discard do
         instance = described_class.new(ctx, integration)
         note = instance.send :reason_note, discard
 
-        expect(note).to eq 'Does not meet internal QC'
+        expect(note).to eq ''
       end
     end
 

--- a/spec/services/metrc_service/plant/discard_spec.rb
+++ b/spec/services/metrc_service/plant/discard_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe MetrcService::Plant::Discard do
 
         stub_request(:post, 'https://sandbox-api-md.metrc.com/plants/v1/destroyplants?licenseNumber=LIC-0001')
           .with(
-            body: [{ Id: nil, Label: '1A4FF010000002200000105', ReasonNote: '', ActualDate: '2019-10-25T00:00:00.000Z' }, { Id: nil, Label: '1A4FF010000002200000104', ReasonNote: '', ActualDate: '2019-10-25T00:00:00.000Z' }, { Id: nil, Label: '1A4FF010000002200000103', ReasonNote: '', ActualDate: '2019-10-25T00:00:00.000Z' }].to_json,
+            body: [{ Id: nil, Label: '1A4FF010000002200000105', ReasonNote: described_class::NOT_SPECIFIED, ActualDate: '2019-10-25T00:00:00.000Z' }, { Id: nil, Label: '1A4FF010000002200000104', ReasonNote: described_class::NOT_SPECIFIED, ActualDate: '2019-10-25T00:00:00.000Z' }, { Id: nil, Label: '1A4FF010000002200000103', ReasonNote: described_class::NOT_SPECIFIED, ActualDate: '2019-10-25T00:00:00.000Z' }].to_json,
             basic_auth: [METRC_API_KEY, integration.secret]
           )
           .to_return(status: 200, body: '', headers: {})
@@ -180,7 +180,7 @@ RSpec.describe MetrcService::Plant::Discard do
 
         stub_request(:post, 'https://sandbox-api-md.metrc.com/plantbatches/v1/destroy?licenseNumber=LIC-0001')
           .with(
-            body: [{ PlantBatch: 'Oct1-Ban-Spl-Can', Count: 5, ReasonNote: '', ActualDate: '2019-10-25T00:00:00.000Z' }].to_json,
+            body: [{ PlantBatch: 'Oct1-Ban-Spl-Can', Count: 5, ReasonNote: described_class::NOT_SPECIFIED, ActualDate: '2019-10-25T00:00:00.000Z' }].to_json,
             basic_auth: [METRC_API_KEY, integration.secret]
           )
           .to_return(status: 200, body: '', headers: {})
@@ -206,7 +206,7 @@ RSpec.describe MetrcService::Plant::Discard do
       expect(payload.first).to eq(
         PlantBatch: 'Oct1-Ban-Spl-Can',
         Count: 1,
-        ReasonNote: '',
+        ReasonNote: described_class::NOT_SPECIFIED,
         ActualDate: now
       )
     end
@@ -245,7 +245,7 @@ RSpec.describe MetrcService::Plant::Discard do
         expect(payload.first).to eq(
           Id: nil,
           Label: '1A4FF01000000220000010',
-          ReasonNote: '',
+          ReasonNote: described_class::NOT_SPECIFIED,
           ActualDate: now
         )
       end
@@ -259,7 +259,7 @@ RSpec.describe MetrcService::Plant::Discard do
         instance = described_class.new(ctx, integration)
         note = instance.send :reason_note, discard
 
-        expect(note).to eq ''
+        expect(note).to eq described_class::NOT_SPECIFIED
       end
     end
 
@@ -271,7 +271,7 @@ RSpec.describe MetrcService::Plant::Discard do
         instance = described_class.new(ctx, integration)
         note = instance.send :reason_note, discard
 
-        expect(note).to eq ''
+        expect(note).to eq described_class::NOT_SPECIFIED
       end
     end
 


### PR DESCRIPTION
PT: https://www.pivotaltracker.com/story/show/172302253

---

~~Branched from #79, merge that first then rebase and review.~~

---

- Removed default hardcoded destroy reason, allowing default reason field to be sent to Metrc: `Not Specified`