### PR TITLE
Revert move phase name to use the completion's sub-stage name instead of the zone name [fixes #174256620]

### DIFF
--- a/app/services/common/base.rb
+++ b/app/services/common/base.rb
@@ -5,7 +5,7 @@ module Common
     extend Memoist
 
     RETRYABLE_ERRORS = [
-      Net::HTTPRetriableError,
+      Net::HTTPRetriableError
     ].freeze
 
     attr_reader :artemis

--- a/app/services/metrc_service/plant/move.rb
+++ b/app/services/metrc_service/plant/move.rb
@@ -105,11 +105,12 @@ module MetrcService
       end
 
       def change_growth_phase
+        phase = current_growth_phase
         payload = {
           Name: batch_tag,
           Count: quantity,
-          StartingTag: immature? ? nil : barcode,
-          GrowthPhase: current_growth_phase,
+          StartingTag: immature?(phase) ? nil : barcode,
+          GrowthPhase: phase,
           NewLocation: location_name,
           GrowthDate: start_time,
           PatientLicenseNumber: nil
@@ -153,8 +154,8 @@ module MetrcService
         @attributes.dig('start_time')
       end
 
-      def immature?
-        normalized_growth_phase != 'Flowering'
+      def immature?(phase = nil)
+        phase != 'Flowering'
       end
 
       def normalized_growth_phase(input = nil)
@@ -187,17 +188,19 @@ module MetrcService
         !tracking_method.nil? && tracking_method != 'none'
       end
 
-      def growth_phase_for_completion(c)
-        normalized_growth_phase(c&.included&.dig(:sub_stages)&.first&.name)
+      def growth_phase_for_completion(comp)
+        normalized_growth_phase(comp&.included&.dig(:sub_stages)&.first&.name)
       end
 
       def current_growth_phase
         growth_phase_for_completion(@completion)
       end
+      memoize :current_growth_phase
 
       def next_previous_growth_phase
         growth_phase_for_completion(@prior_move)
       end
+      memoize :next_previous_growth_phase
 
       alias previous_growth_phase next_previous_growth_phase
     end

--- a/app/services/metrc_service/plant/move.rb
+++ b/app/services/metrc_service/plant/move.rb
@@ -4,6 +4,7 @@ module MetrcService
       extend Memoist
 
       DEFAULT_MOVE_STEP = :change_growth_phase
+      DEFAULT_COMPLETION_INCLUDES = 'zone,barcodes,sub_zone,action_result,crop_batch_state.seeding_unit,crop_batch_state.zone.sub_stage'.freeze
 
       def call
         log("Next step: #{next_step_name}. Batch ID #{@batch_id}, completion ID #{@completion_id}")
@@ -30,8 +31,7 @@ module MetrcService
 
         return if previous_move.nil?
 
-        @prior_move = batch.completion(previous_move&.completion_id,
-                                       include: 'zone,barcodes,sub_zone,action_result,crop_batch_state.seeding_unit')
+        @prior_move = batch.completion(previous_move&.completion_id, include: DEFAULT_COMPLETION_INCLUDES)
       end
       memoize :prior_move
 
@@ -44,8 +44,7 @@ module MetrcService
       end
 
       def next_step_name
-        @completion = batch.completion(@completion_id,
-                                       include: 'zone,barcodes,sub_zone,action_result,crop_batch_state.seeding_unit')
+        @completion = batch.completion(@completion_id, include: DEFAULT_COMPLETION_INCLUDES)
 
         next_step(prior_move, @completion)
       end
@@ -55,7 +54,7 @@ module MetrcService
         return DEFAULT_MOVE_STEP if previous_completion.nil? || completion.nil?
 
         @prior_move ||= previous_completion
-        new_growth_phase = normalized_growth_phase(completion&.options['zone_name'])
+        new_growth_phase = normalized_growth_phase(completion&.included&.dig(:sub_stages)&.first&.name)
 
         # Yeah, I don't like this either.
         previous_item_tracking_method_has_barcodes = items_have_barcodes?(previous_completion.included&.dig(:seeding_units)&.first&.item_tracking_method)
@@ -110,7 +109,7 @@ module MetrcService
           Name: batch_tag,
           Count: quantity,
           StartingTag: immature? ? nil : barcode,
-          GrowthPhase: normalized_growth_phase(@completion&.options&.dig('zone_name')),
+          GrowthPhase: normalized_growth_phase(@completion&.included&.dig(:sub_stages)&.first&.name),
           NewLocation: location_name,
           GrowthDate: start_time,
           PatientLicenseNumber: nil
@@ -125,7 +124,7 @@ module MetrcService
             Id: nil,
             Label: item&.relationships&.dig('barcode', 'data', 'id'),
             NewLabel: nil,
-            GrowthPhase: normalized_growth_phase(@completion&.options&.dig('zone_name')),
+            GrowthPhase: normalized_growth_phase(@completion&.included&.dig(:sub_stages)&.first&.name),
             NewLocation: location_name,
             NewRoom: location_name,
             GrowthDate: start_time
@@ -189,7 +188,7 @@ module MetrcService
       end
 
       def previous_growth_phase
-        normalized_growth_phase(@prior_move.options['zone_name'])
+        normalized_growth_phase(@prior_move.included&.dig(:sub_stages)&.first&.name)
       end
     end
   end

--- a/spec/services/metrc_service/plant/move_spec.rb
+++ b/spec/services/metrc_service/plant/move_spec.rb
@@ -98,10 +98,10 @@ RSpec.describe MetrcService::Plant::Move do
         stub_request(:get, "#{ENV['ARTEMIS_BASE_URI']}/api/v3/facilities/#{facility_id}/batches/#{batch_id}/items?filter[seeding_unit_id]=#{seeding_unit_id}&include=barcodes,seeding_unit")
           .to_return(body: load_response_json("api/sync/facilities/#{facility_id}/batches/#{batch_id}/items"))
 
-        stub_request(:get, "#{ENV['ARTEMIS_BASE_URI']}/api/v3/facilities/#{facility_id}/completions/3000?include=zone,barcodes,sub_zone,action_result,crop_batch_state.seeding_unit,crop_batch_state.zone.sub_stage")
+        stub_request(:get, "#{ENV['ARTEMIS_BASE_URI']}/api/v3/facilities/#{facility_id}/completions/3000?include=action_result,crop_batch_state.seeding_unit,crop_batch_state.zone.sub_stage")
           .to_return(body: load_response_json('api/completions/3000'))
 
-        stub_request(:get, "#{ENV['ARTEMIS_BASE_URI']}/api/v3/facilities/#{facility_id}/completions/#{previous_move.completion_id}?include=zone,barcodes,sub_zone,action_result,crop_batch_state.seeding_unit,crop_batch_state.zone.sub_stage")
+        stub_request(:get, "#{ENV['ARTEMIS_BASE_URI']}/api/v3/facilities/#{facility_id}/completions/#{previous_move.completion_id}?include=action_result,crop_batch_state.seeding_unit,crop_batch_state.zone.sub_stage")
           .to_return(body: load_response_json('api/completions/3000'))
 
         stub_request(:get, "#{ENV['ARTEMIS_BASE_URI']}/api/v3/facilities/#{facility_id}/completions?filter%5Baction_type%5D=generate&filter%5Bparent_id%5D=3000")
@@ -145,10 +145,10 @@ RSpec.describe MetrcService::Plant::Move do
         stub_request(:get, "#{ENV['ARTEMIS_BASE_URI']}/api/v3/facilities/#{facility_id}/batches/#{batch_id}/items?filter[seeding_unit_id]=#{seeding_unit_id}&include=barcodes,seeding_unit")
           .to_return(body: load_response_json("api/sync/facilities/#{facility_id}/batches/#{batch_id}/items"))
 
-        stub_request(:get, "#{ENV['ARTEMIS_BASE_URI']}/api/v3/facilities/#{facility_id}/completions/3000?include=zone,barcodes,sub_zone,action_result,crop_batch_state.seeding_unit,crop_batch_state.zone.sub_stage")
+        stub_request(:get, "#{ENV['ARTEMIS_BASE_URI']}/api/v3/facilities/#{facility_id}/completions/3000?include=action_result,crop_batch_state.seeding_unit,crop_batch_state.zone.sub_stage")
           .to_return(body: load_response_json('api/completions/3000'))
 
-        stub_request(:get, "#{ENV['ARTEMIS_BASE_URI']}/api/v3/facilities/#{facility_id}/completions/#{previous_move.completion_id}?include=zone,barcodes,sub_zone,action_result,crop_batch_state.seeding_unit,crop_batch_state.zone.sub_stage")
+        stub_request(:get, "#{ENV['ARTEMIS_BASE_URI']}/api/v3/facilities/#{facility_id}/completions/#{previous_move.completion_id}?include=action_result,crop_batch_state.seeding_unit,crop_batch_state.zone.sub_stage")
           .to_return(body: load_response_json('api/completions/3000'))
 
         stub_request(:get, "#{ENV['ARTEMIS_BASE_URI']}/api/v3/facilities/#{facility_id}/completions?filter%5Baction_type%5D=generate&filter%5Bparent_id%5D=3000")
@@ -240,10 +240,10 @@ RSpec.describe MetrcService::Plant::Move do
           .with(body: expected_payload.to_json)
           .to_return(status: 200)
 
-        stub_request(:get, "#{ENV['ARTEMIS_BASE_URI']}/api/v3/facilities/#{facility_id}/completions/#{completion_id}?include=zone,barcodes,sub_zone,action_result,crop_batch_state.seeding_unit,crop_batch_state.zone.sub_stage")
+        stub_request(:get, "#{ENV['ARTEMIS_BASE_URI']}/api/v3/facilities/#{facility_id}/completions/#{completion_id}?include=action_result,crop_batch_state.seeding_unit,crop_batch_state.zone.sub_stage")
           .to_return(body: load_response_json('api/completions/3000'))
 
-        stub_request(:get, "#{ENV['ARTEMIS_BASE_URI']}/api/v3/facilities/#{facility_id}/completions/#{previous_move.completion_id}?include=zone,barcodes,sub_zone,action_result,crop_batch_state.seeding_unit,crop_batch_state.zone.sub_stage")
+        stub_request(:get, "#{ENV['ARTEMIS_BASE_URI']}/api/v3/facilities/#{facility_id}/completions/#{previous_move.completion_id}?include=action_result,crop_batch_state.seeding_unit,crop_batch_state.zone.sub_stage")
           .to_return(body: load_response_json('api/completions/3000'))
 
         @stubs << stub_request(:post, 'https://sandbox-api-md.metrc.com/plants/v1/harvestplants?licenseNumber=LIC-0001')

--- a/spec/services/metrc_service/plant/move_spec.rb
+++ b/spec/services/metrc_service/plant/move_spec.rb
@@ -609,26 +609,22 @@ RSpec.describe MetrcService::Plant::Move do
 
     context 'with an immature batch' do
       let(:expected_payload) do
-        [
-          {
-            Name: batch_tag,
-            Count: quantity,
-            StartingTag: nil,
-            GrowthPhase: normalized_growth_phase,
-            NewLocation: location_name,
-            GrowthDate: start_time,
-            PatientLicenseNumber: nil
-          }
-        ]
-      end
-
-      before do
-        expect_any_instance_of(described_class)
-          .to receive(:immature?)
-          .and_return(true)
+        [{
+          Name: batch_tag,
+          Count: quantity,
+          StartingTag: nil,
+          GrowthPhase: normalized_growth_phase,
+          NewLocation: location_name,
+          GrowthDate: start_time,
+          PatientLicenseNumber: nil
+        }]
       end
 
       it 'calls the Metrc client method' do
+        expect_any_instance_of(described_class)
+          .to receive(:immature?)
+          .and_return(true)
+
         subject.should_receive(:call_metrc)
           .with(:change_growth_phase, expected_payload)
           .and_call_original

--- a/spec/services/metrc_service/plant/move_spec.rb
+++ b/spec/services/metrc_service/plant/move_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe MetrcService::Plant::Move do
       end
     end
 
-    describe 'moving to vegetative substage' do
+    describe 'moving to vegetative phase' do
       let(:seeding_unit_id) { 7 }
       let(:previous_move) { create(:transaction, :successful, :move, account: account, integration: integration, batch_id: batch_id) }
       let(:expected_payload) do
@@ -98,27 +98,29 @@ RSpec.describe MetrcService::Plant::Move do
         stub_request(:get, "#{ENV['ARTEMIS_BASE_URI']}/api/v3/facilities/#{facility_id}/batches/#{batch_id}/items?filter[seeding_unit_id]=#{seeding_unit_id}&include=barcodes,seeding_unit")
           .to_return(body: load_response_json("api/sync/facilities/#{facility_id}/batches/#{batch_id}/items"))
 
-        stub_request(:get, "#{ENV['ARTEMIS_BASE_URI']}/api/v3/facilities/#{facility_id}/completions/3000?include=zone,barcodes,sub_zone,action_result,crop_batch_state.seeding_unit")
+        stub_request(:get, "#{ENV['ARTEMIS_BASE_URI']}/api/v3/facilities/#{facility_id}/completions/3000?include=zone,barcodes,sub_zone,action_result,crop_batch_state.seeding_unit,crop_batch_state.zone.sub_stage")
           .to_return(body: load_response_json('api/completions/3000'))
 
-        stub_request(:get, "#{ENV['ARTEMIS_BASE_URI']}/api/v3/facilities/#{facility_id}/completions/#{previous_move.completion_id}?include=zone,barcodes,sub_zone,action_result,crop_batch_state.seeding_unit")
+        stub_request(:get, "#{ENV['ARTEMIS_BASE_URI']}/api/v3/facilities/#{facility_id}/completions/#{previous_move.completion_id}?include=zone,barcodes,sub_zone,action_result,crop_batch_state.seeding_unit,crop_batch_state.zone.sub_stage")
           .to_return(body: load_response_json('api/completions/3000'))
 
         stub_request(:get, "#{ENV['ARTEMIS_BASE_URI']}/api/v3/facilities/#{facility_id}/completions?filter%5Baction_type%5D=generate&filter%5Bparent_id%5D=3000")
           .to_return(body: { data: [] }.to_json)
-
-        expect_any_instance_of(MetrcService::Resource::WetWeight)
-          .not_to receive(:harvest_plants)
 
         stub_request(:put, 'https://sandbox-api-md.metrc.com/plantbatches/v1/moveplantbatches?licenseNumber=LIC-0001')
           .with(body: expected_payload.to_json)
           .to_return(status: 200)
       end
 
-      it { is_expected.to be_success }
+      it 'is successful' do
+        expect_any_instance_of(MetrcService::Resource::WetWeight)
+          .not_to receive(:harvest_plants)
+
+        expect(subject).to be_success
+      end
     end
 
-    describe 'moving to flower substage' do
+    describe 'moving to flower phase' do
       let(:batch_id) { 82 }
       let(:seeding_unit_id) { 7 }
       let(:previous_move) { create(:transaction, :successful, :move, account: account, integration: integration, batch_id: batch_id) }
@@ -143,24 +145,26 @@ RSpec.describe MetrcService::Plant::Move do
         stub_request(:get, "#{ENV['ARTEMIS_BASE_URI']}/api/v3/facilities/#{facility_id}/batches/#{batch_id}/items?filter[seeding_unit_id]=#{seeding_unit_id}&include=barcodes,seeding_unit")
           .to_return(body: load_response_json("api/sync/facilities/#{facility_id}/batches/#{batch_id}/items"))
 
-        stub_request(:get, "#{ENV['ARTEMIS_BASE_URI']}/api/v3/facilities/#{facility_id}/completions/3000?include=zone,barcodes,sub_zone,action_result,crop_batch_state.seeding_unit")
+        stub_request(:get, "#{ENV['ARTEMIS_BASE_URI']}/api/v3/facilities/#{facility_id}/completions/3000?include=zone,barcodes,sub_zone,action_result,crop_batch_state.seeding_unit,crop_batch_state.zone.sub_stage")
           .to_return(body: load_response_json('api/completions/3000'))
 
-        stub_request(:get, "#{ENV['ARTEMIS_BASE_URI']}/api/v3/facilities/#{facility_id}/completions/#{previous_move.completion_id}?include=zone,barcodes,sub_zone,action_result,crop_batch_state.seeding_unit")
+        stub_request(:get, "#{ENV['ARTEMIS_BASE_URI']}/api/v3/facilities/#{facility_id}/completions/#{previous_move.completion_id}?include=zone,barcodes,sub_zone,action_result,crop_batch_state.seeding_unit,crop_batch_state.zone.sub_stage")
           .to_return(body: load_response_json('api/completions/3000'))
 
         stub_request(:get, "#{ENV['ARTEMIS_BASE_URI']}/api/v3/facilities/#{facility_id}/completions?filter%5Baction_type%5D=generate&filter%5Bparent_id%5D=3000")
           .to_return(body: { data: [] }.to_json)
-
-        expect_any_instance_of(MetrcService::Resource::WetWeight)
-          .not_to receive(:harvest_plants)
 
         stub_request(:put, 'https://sandbox-api-md.metrc.com/plantbatches/v1/moveplantbatches?licenseNumber=LIC-0001')
           .with(body: expected_payload.to_json)
           .to_return(status: 200)
       end
 
-      it { is_expected.to be_success }
+      it 'is successful' do
+        expect_any_instance_of(MetrcService::Resource::WetWeight)
+          .not_to receive(:harvest_plants)
+
+        expect(subject).to be_success
+      end
     end
 
     describe 'moving and generating wet_weight' do
@@ -236,10 +240,10 @@ RSpec.describe MetrcService::Plant::Move do
           .with(body: expected_payload.to_json)
           .to_return(status: 200)
 
-        stub_request(:get, "#{ENV['ARTEMIS_BASE_URI']}/api/v3/facilities/#{facility_id}/completions/#{completion_id}?include=zone,barcodes,sub_zone,action_result,crop_batch_state.seeding_unit")
+        stub_request(:get, "#{ENV['ARTEMIS_BASE_URI']}/api/v3/facilities/#{facility_id}/completions/#{completion_id}?include=zone,barcodes,sub_zone,action_result,crop_batch_state.seeding_unit,crop_batch_state.zone.sub_stage")
           .to_return(body: load_response_json('api/completions/3000'))
 
-        stub_request(:get, "#{ENV['ARTEMIS_BASE_URI']}/api/v3/facilities/#{facility_id}/completions/#{previous_move.completion_id}?include=zone,barcodes,sub_zone,action_result,crop_batch_state.seeding_unit")
+        stub_request(:get, "#{ENV['ARTEMIS_BASE_URI']}/api/v3/facilities/#{facility_id}/completions/#{previous_move.completion_id}?include=zone,barcodes,sub_zone,action_result,crop_batch_state.seeding_unit,crop_batch_state.zone.sub_stage")
           .to_return(body: load_response_json('api/completions/3000'))
 
         @stubs << stub_request(:post, 'https://sandbox-api-md.metrc.com/plants/v1/harvestplants?licenseNumber=LIC-0001')
@@ -311,16 +315,12 @@ RSpec.describe MetrcService::Plant::Move do
 
     context 'with an unsopported growth phase' do
       let(:first_move) do
-        response = create_response('api/completions/762428-no-seeding')
-        completion = artemis_client.process_response(response, 'completions')
-        completion.options['zone_name'] = nil
-        completion
+        response = create_response('api/completions/762428-no-substage-no-seeding')
+        artemis_client.process_response(response, 'completions')
       end
       let(:second_move) do
-        response = create_response('api/completions/762429-no-seeding')
-        completion = artemis_client.process_response(response, 'completions')
-        completion.options['zone_name'] = nil
-        completion
+        response = create_response('api/completions/762429-no-substage-no-seeding')
+        artemis_client.process_response(response, 'completions')
       end
 
       it 'returns the default move step' do
@@ -340,18 +340,13 @@ RSpec.describe MetrcService::Plant::Move do
     end
 
     context 'when a batch is moved from clone to clone and there\'s no barcodes' do
-      let(:zone_name) { 'Clones' }
       let(:first_move) do
         response = create_response('api/completions/762428-no-seeding')
-        completion = artemis_client.process_response(response, 'completions')
-        completion.options['zone_name'] = zone_name
-        completion
+        artemis_client.process_response(response, 'completions')
       end
       let(:second_move) do
         response = create_response('api/completions/762429-no-seeding')
-        completion = artemis_client.process_response(response, 'completions')
-        completion.options['zone_name'] = zone_name
-        completion
+        artemis_client.process_response(response, 'completions')
       end
 
       it 'returns the move plant batches' do
@@ -360,18 +355,13 @@ RSpec.describe MetrcService::Plant::Move do
     end
 
     context 'with a previous flowering zone to a new flowering zone, and with barcodes' do
-      let(:zone_name) { 'Flowering' }
       let(:first_move) do
         response = create_response('api/completions/762428-flowering-preprinted')
-        completion = artemis_client.process_response(response, 'completions')
-        completion.options['zone_name'] = zone_name
-        completion
+        artemis_client.process_response(response, 'completions')
       end
       let(:second_move) do
         response = create_response('api/completions/762429-flowering-preprinted')
-        completion = artemis_client.process_response(response, 'completions')
-        completion.options['zone_name'] = zone_name
-        completion
+        artemis_client.process_response(response, 'completions')
       end
 
       it 'returns the change_plants_growth_phase step' do
@@ -380,18 +370,13 @@ RSpec.describe MetrcService::Plant::Move do
     end
 
     context 'with a previous vegetative zone to a new vegetative zone, and with no previous barcode' do
-      let(:zone_name) { 'Vegetative' }
       let(:first_move) do
-        response = create_response('api/completions/762428-no-seeding')
-        completion = artemis_client.process_response(response, 'completions')
-        completion.options['zone_name'] = zone_name
-        completion
+        response = create_response('api/completions/762428-vegetative-no-seeding')
+        artemis_client.process_response(response, 'completions')
       end
       let(:second_move) do
-        response = create_response('api/completions/762429-flowering-preprinted')
-        completion = artemis_client.process_response(response, 'completions')
-        completion.options['zone_name'] = zone_name
-        completion
+        response = create_response('api/completions/762429-vegetative-preprinted')
+        artemis_client.process_response(response, 'completions')
       end
 
       it 'returns the change_growth_phase step' do
@@ -400,12 +385,9 @@ RSpec.describe MetrcService::Plant::Move do
     end
 
     context 'with a previous flowering zone to a new flowering zone, and with no previous barcode' do
-      let(:zone_name) { 'Flowering' }
       let(:first_move) do
-        response = create_response('api/completions/762428-no-seeding')
-        completion = artemis_client.process_response(response, 'completions')
-        completion.options['zone_name'] = zone_name
-        completion
+        response = create_response('api/completions/762428-flowering-no-seeding')
+        artemis_client.process_response(response, 'completions')
       end
       let(:second_move) do
         response = create_response('api/completions/762429-flowering-preprinted')
@@ -418,79 +400,61 @@ RSpec.describe MetrcService::Plant::Move do
     end
 
     context 'with a previous clone zone to a new clone zone, and with barcodes' do
-      let(:zone_name) { 'Clone' }
       let(:first_move) do
-        response = create_response('api/completions/762428-flowering-preprinted')
-        completion = artemis_client.process_response(response, 'completions')
-        completion.options['zone_name'] = zone_name
-        completion
+        response = create_response('api/completions/762428-clone-preprinted')
+        artemis_client.process_response(response, 'completions')
       end
       let(:second_move) do
-        response = create_response('api/completions/762429-flowering-preprinted')
-        completion = artemis_client.process_response(response, 'completions')
-        completion.options['zone_name'] = zone_name
-        completion
+        response = create_response('api/completions/762429-clone-preprinted')
+        artemis_client.process_response(response, 'completions')
       end
 
-      it 'returns the change_plant_growth_phases step' do
+      it 'returns the move_plants step' do
         expect(subject).to be :move_plants
       end
     end
 
     context 'with a previous curing zone to a new drying zone, and with barcodes' do
       let(:first_move) do
-        response = create_response('api/completions/762428-flowering-preprinted')
-        completion = artemis_client.process_response(response, 'completions')
-        completion.options['zone_name'] = 'Curing'
-        completion
+        response = create_response('api/completions/762428-curing-preprinted')
+        artemis_client.process_response(response, 'completions')
       end
       let(:second_move) do
-        response = create_response('api/completions/762429-flowering-preprinted')
-        completion = artemis_client.process_response(response, 'completions')
-        completion.options['zone_name'] = 'Drying'
-        completion
+        response = create_response('api/completions/762429-drying-preprinted')
+        artemis_client.process_response(response, 'completions')
       end
 
-      it 'returns the change_plant_growth_phases step' do
+      it 'returns the move_harvest step' do
         expect(subject).to be :move_harvest
       end
     end
 
     context 'with a previous curing zone to a new drying zone, and with barcodes' do
       let(:first_move) do
-        response = create_response('api/completions/762428-flowering-preprinted')
-        completion = artemis_client.process_response(response, 'completions')
-        completion.options['zone_name'] = 'Drying'
-        completion
+        response = create_response('api/completions/762428-drying-preprinted')
+        artemis_client.process_response(response, 'completions')
       end
       let(:second_move) do
-        response = create_response('api/completions/762429-flowering-preprinted')
-        completion = artemis_client.process_response(response, 'completions')
-        completion.options['zone_name'] = 'Curing'
-        completion
+        response = create_response('api/completions/762429-curing-preprinted')
+        artemis_client.process_response(response, 'completions')
       end
 
-      it 'returns the change_plant_growth_phases step' do
+      it 'returns the move_harvest step' do
         expect(subject).to be :move_harvest
       end
     end
 
     context 'with a previous curing zone to a new curing zone, and with barcodes' do
-      let(:zone_name) { 'Curing' }
       let(:first_move) do
-        response = create_response('api/completions/762428-flowering-preprinted')
-        completion = artemis_client.process_response(response, 'completions')
-        completion.options['zone_name'] = zone_name
-        completion
+        response = create_response('api/completions/762428-curing-preprinted')
+        artemis_client.process_response(response, 'completions')
       end
       let(:second_move) do
-        response = create_response('api/completions/762429-flowering-preprinted')
-        completion = artemis_client.process_response(response, 'completions')
-        completion.options['zone_name'] = zone_name
-        completion
+        response = create_response('api/completions/762429-curing-preprinted')
+        artemis_client.process_response(response, 'completions')
       end
 
-      it 'returns the change_plant_growth_phases step' do
+      it 'returns the move_harvest step' do
         expect(subject).to be :move_harvest
       end
     end
@@ -498,19 +462,19 @@ RSpec.describe MetrcService::Plant::Move do
     context 'with a previous curing zone to a new curing zone, and with barcodes' do
       let(:zone_name) { 'Drying' }
       let(:first_move) do
-        response = create_response('api/completions/762428-flowering-preprinted')
+        response = create_response('api/completions/762428-drying-preprinted')
         completion = artemis_client.process_response(response, 'completions')
         completion.options['zone_name'] = zone_name
         completion
       end
       let(:second_move) do
-        response = create_response('api/completions/762429-flowering-preprinted')
+        response = create_response('api/completions/762429-drying-preprinted')
         completion = artemis_client.process_response(response, 'completions')
         completion.options['zone_name'] = zone_name
         completion
       end
 
-      it 'returns the change_plant_growth_phases step' do
+      it 'returns the move_harvest step' do
         expect(subject).to be :move_harvest
       end
     end

--- a/spec/services/metrc_service/plant/start_spec.rb
+++ b/spec/services/metrc_service/plant/start_spec.rb
@@ -241,11 +241,148 @@ RSpec.describe MetrcService::Plant::Start do
     end
 
     describe '#create_plantings_from_package' do
-      subject { described_class.call(ctx, integration) }
-
       describe '#create_plantings_from_package_payload' do
-        context 'with no custom data', skip: 'Notifies Bugsnag?' do
+        context 'with no custom data' do
           let(:now) { Time.zone.now.strftime('%Y-%m-%d') }
+          subject { described_class.new(ctx, integration) }
+
+          before do
+            stub_request(:get, 'https://portal.artemisag.com/api/v3/facilities/1568')
+              .to_return(body: { data: { id: '1568', type: 'facilities', attributes: { id: 1568, name: 'Rare Dankness' } } }.to_json)
+
+            stub_request(:get, 'https://portal.artemisag.com/api/v3/facilities/1568/batches/2002?include=zone,zone.sub_stage,barcodes,custom_data,seeding_unit,harvest_unit,sub_zone,custom_data.custom_field')
+              .to_return(body: {
+                data: {
+                  id: '2002',
+                  type: 'batches',
+                  attributes: {
+                    id: 2002,
+                    arbitrary_id: 'Jun19-Bok-Cho',
+                    quantity: '100',
+                    crop_variety: 'Banana Split',
+                    seeded_at: now,
+                    zone_name: 'Germination',
+                    crop: 'Cannabis'
+                  },
+                  relationships: {
+                    'seeding_unit': {
+                      'data': {
+                        'id': '1235',
+                        'type': 'seeding_units'
+                      }
+                    },
+                    'custom_data': {
+                      'data': [
+                        {
+                          'type': 'custom_data',
+                          'id': '66998'
+                        }
+                      ]
+                    },
+                    'barcodes': {
+                      'data': [
+                        {
+                          'type': 'barcodes',
+                          'id': '1A406020000E4E9000003989'
+                        }
+                      ]
+                    }
+                  }
+                },
+                included: [
+                  {
+                    id: '1234',
+                    type: 'zones',
+                    attributes: {
+                      id: 1234,
+                      seeding_unit: {
+                        name: 'Clone'
+                      }
+                    }
+                  },
+                  {
+                    id: '1235',
+                    type: 'seeding_units',
+                    attributes: {
+                      id: 1235,
+                      item_tracking_method: 'preprinted',
+                      name: 'Clone'
+                    }
+                  },
+                  {
+                    id: '66998',
+                    type: 'custom_data',
+                    attributes: {
+                      id: 66998,
+                      value: '1A4060300003779000013229',
+                      crop_batch_id: 108064,
+                      custom_field_id: 408
+                    },
+                    relationships: {
+                      custom_field: {
+                        data: {
+                          id: '407',
+                          type: 'custom_fields'
+                        }
+                      },
+                      crop_batch: {
+                        data: {
+                          id: '2002',
+                          type: 'crop_batches'
+                        }
+                      }
+                    }
+                  },
+                  {
+                    id: '407',
+                    type: 'custom_fields',
+                    attributes: {
+                      id: 407,
+                      name: 'Source Package Id (Metrc)',
+                      organization_id: 1062,
+                      position: 0,
+                      kind: 'text',
+                      status: 'active'
+                    },
+                    relationships: {
+                      stage: {
+                        data: {
+                          id: '1068',
+                          type: 'stages'
+                        }
+                      }
+                    }
+                  }
+                ]
+              }.to_json)
+          end
+
+          it 'returns raises an Invalid Operation exception' do
+            expect { subject.send(:create_plantings_from_package_payload) }.to raise_error(InvalidOperation)
+          end
+        end
+
+        context 'with custom data' do
+          let(:now) { Time.zone.now.strftime('%Y-%m-%d') }
+          let(:expected_payload) do
+            [
+              {
+                LocationName: nil,
+                PackageAdjustmentAmount: 0,
+                PackageAdjustmentUnitOfMeasureName: 'Ounces',
+                PackageLabel: '1A4060300003779000013229',
+                PatientLicenseNumber: nil,
+                PlantBatchName: '1A406020000E4E9000003989',
+                PlantBatchType: 'Clone',
+                PlantCount: 100,
+                PlantedDate: now,
+                RoomName: nil,
+                StrainName: 'Banana Split',
+                UnpackagedDate: now
+              }
+            ]
+          end
+          subject { described_class.new(ctx, integration) }
 
           before do
             stub_request(:get, 'https://portal.artemisag.com/api/v3/facilities/1568')
@@ -356,14 +493,10 @@ RSpec.describe MetrcService::Plant::Start do
                   }
                 ]
               }.to_json)
-
-            stub_request(:post, 'https://sandbox-api-ca.metrc.com/packages/v1/create/plantings?licenseNumber=LIC-0001')
-              .with(body: [{Name: '1A4FF01000000220000010', Type: 'Clone', Count: 100, Strain: 'Banana Split', Location: 'Germination', PatientLicenseNumber: nil, ActualDate: now}].to_json)
-              .to_return(status: 200, body: '', headers: {})
           end
 
-          it 'returns raises an Invalid Operation exception' do
-            expect { subject.send(:create_plantings_from_package_payload) }.to raise_error(InvalidOperation)
+          it 'returns the expected payload' do
+            expect(subject.send(:create_plantings_from_package_payload)).to eq(expected_payload)
           end
         end
       end
@@ -399,7 +532,7 @@ RSpec.describe MetrcService::Plant::Start do
             .with(body: expected_payload.to_json)
             .to_return(status: 200, body: '', headers: {})
 
-          stub_request(:get, "#{ENV['ARTEMIS_BASE_URI']}/api/v3/facilities/1568/completions/3000?include=zone,barcodes,sub_zone,action_result,crop_batch_state.seeding_unit")
+          stub_request(:get, "#{ENV['ARTEMIS_BASE_URI']}/api/v3/facilities/1568/completions/3000?include=zone,barcodes,sub_zone,action_result,crop_batch_state.seeding_unit,crop_batch_state.zone.sub_stage")
             .to_return(body: load_response_json('api/completions/3000'))
 
           stub_request(:post, 'https://sandbox-api-ca.metrc.com/plantbatches/v1/changegrowthphase?licenseNumber=LIC-0001')

--- a/spec/services/metrc_service/plant/start_spec.rb
+++ b/spec/services/metrc_service/plant/start_spec.rb
@@ -532,7 +532,7 @@ RSpec.describe MetrcService::Plant::Start do
             .with(body: expected_payload.to_json)
             .to_return(status: 200, body: '', headers: {})
 
-          stub_request(:get, "#{ENV['ARTEMIS_BASE_URI']}/api/v3/facilities/1568/completions/3000?include=zone,barcodes,sub_zone,action_result,crop_batch_state.seeding_unit,crop_batch_state.zone.sub_stage")
+          stub_request(:get, "#{ENV['ARTEMIS_BASE_URI']}/api/v3/facilities/1568/completions/3000?include=action_result,crop_batch_state.seeding_unit,crop_batch_state.zone.sub_stage")
             .to_return(body: load_response_json('api/completions/3000'))
 
           stub_request(:post, 'https://sandbox-api-ca.metrc.com/plantbatches/v1/changegrowthphase?licenseNumber=LIC-0001')

--- a/spec/support/data/api/completions/3000.json
+++ b/spec/support/data/api/completions/3000.json
@@ -116,6 +116,329 @@
         "secondary_display_capacity": null,
         "item_tracking_method": "none"
       }
+    },
+    {
+      "id": "7094",
+      "type": "zones",
+      "attributes": {
+        "id": 7094,
+        "facility_id": 1634,
+        "name": "Zone 1",
+        "slug": "zone-1",
+        "zone_type": "generic",
+        "created_at": "2020-03-24T04:13:48.032Z",
+        "updated_at": "2020-07-13T20:41:30.798Z",
+        "status": "active",
+        "position": null,
+        "size": 0,
+        "seeding_unit": {
+          "id": 3601,
+          "name": "Plant (barcoded)",
+          "zones": [
+            {
+              "id": 7098,
+              "slug": "drycure--dry-",
+              "name": "Dry/Cure [Dry]",
+              "seeding_unit_id": 3601,
+              "zone_type": "generic",
+              "sub_zones": []
+            },
+            {
+              "id": 7094,
+              "slug": "zone-1",
+              "name": "Zone 1",
+              "seeding_unit_id": 3601,
+              "zone_type": "generic",
+              "sub_zones": [
+                {
+                  "id": 12232,
+                  "name": "Table 1",
+                  "slug": "table-1-48"
+                },
+                {
+                  "id": 12233,
+                  "name": "Table 2",
+                  "slug": "table-2-47"
+                },
+                {
+                  "id": 12234,
+                  "name": "Table 3",
+                  "slug": "table-3-41"
+                }
+              ]
+            },
+            {
+              "id": 7202,
+              "slug": "zone-2",
+              "name": "Zone 2",
+              "seeding_unit_id": 3601,
+              "zone_type": "generic",
+              "sub_zones": [
+                {
+                  "id": 12235,
+                  "name": "Table 4",
+                  "slug": "table-4-40"
+                },
+                {
+                  "id": 12236,
+                  "name": "Table 5",
+                  "slug": "table-5-40"
+                },
+                {
+                  "id": 12237,
+                  "name": "Table 6",
+                  "slug": "table-6-40"
+                }
+              ]
+            },
+            {
+              "id": 7095,
+              "slug": "zone-3",
+              "name": "Zone 3",
+              "seeding_unit_id": 3601,
+              "zone_type": "generic",
+              "sub_zones": [
+                {
+                  "id": 12238,
+                  "name": "Table 7",
+                  "slug": "table-7-39"
+                },
+                {
+                  "id": 12239,
+                  "name": "Table 8",
+                  "slug": "table-8-5"
+                },
+                {
+                  "id": 12240,
+                  "name": "Table 9",
+                  "slug": "table-9-1"
+                },
+                {
+                  "id": 12241,
+                  "name": "Table 10",
+                  "slug": "table-10-1"
+                }
+              ]
+            },
+            {
+              "id": 7203,
+              "slug": "zone-4",
+              "name": "Zone 4",
+              "seeding_unit_id": 3601,
+              "zone_type": "generic",
+              "sub_zones": [
+                {
+                  "id": 12242,
+                  "name": "Table 11",
+                  "slug": "table-11-1"
+                },
+                {
+                  "id": 12243,
+                  "name": "Table 12",
+                  "slug": "table-12-1"
+                },
+                {
+                  "id": 12244,
+                  "name": "Table 13",
+                  "slug": "table-13-1"
+                },
+                {
+                  "id": 12245,
+                  "name": "Table 14",
+                  "slug": "table-14-1"
+                }
+              ]
+            },
+            {
+              "id": 7096,
+              "slug": "zone-5",
+              "name": "Zone 5",
+              "seeding_unit_id": 3601,
+              "zone_type": "generic",
+              "sub_zones": [
+                {
+                  "id": 12246,
+                  "name": "Table 15",
+                  "slug": "table-15-1"
+                },
+                {
+                  "id": 12247,
+                  "name": "Table 16",
+                  "slug": "table-16-1"
+                },
+                {
+                  "id": 12248,
+                  "name": "Table 17",
+                  "slug": "table-17"
+                }
+              ]
+            },
+            {
+              "id": 7204,
+              "slug": "zone-6",
+              "name": "Zone 6",
+              "seeding_unit_id": 3601,
+              "zone_type": "generic",
+              "sub_zones": [
+                {
+                  "id": 12249,
+                  "name": "Table 18",
+                  "slug": "table-18-1"
+                },
+                {
+                  "id": 12250,
+                  "name": "Table 19",
+                  "slug": "table-19"
+                },
+                {
+                  "id": 12251,
+                  "name": "Table 20",
+                  "slug": "table-20"
+                }
+              ]
+            },
+            {
+              "id": 7097,
+              "slug": "zone-7",
+              "name": "Zone 7",
+              "seeding_unit_id": 3601,
+              "zone_type": "generic",
+              "sub_zones": [
+                {
+                  "id": 12252,
+                  "name": "Table 21",
+                  "slug": "table-21"
+                },
+                {
+                  "id": 12253,
+                  "name": "Table 22",
+                  "slug": "table-22"
+                },
+                {
+                  "id": 12254,
+                  "name": "Table 23",
+                  "slug": "table-23"
+                },
+                {
+                  "id": 12255,
+                  "name": "Table 24",
+                  "slug": "table-24"
+                },
+                {
+                  "id": 12256,
+                  "name": "Table 25",
+                  "slug": "table-25"
+                },
+                {
+                  "id": 12257,
+                  "name": "Table 26",
+                  "slug": "table-26"
+                },
+                {
+                  "id": 12258,
+                  "name": "Table 27",
+                  "slug": "table-27"
+                }
+              ]
+            },
+            {
+              "id": 7205,
+              "slug": "zone-8",
+              "name": "Zone 8",
+              "seeding_unit_id": 3601,
+              "zone_type": "generic",
+              "sub_zones": [
+                {
+                  "id": 12259,
+                  "name": "Table 28",
+                  "slug": "table-28"
+                },
+                {
+                  "id": 12260,
+                  "name": "Table 29",
+                  "slug": "table-29"
+                },
+                {
+                  "id": 12261,
+                  "name": "Table 30",
+                  "slug": "table-30"
+                },
+                {
+                  "id": 12262,
+                  "name": "Table 31",
+                  "slug": "table-31"
+                },
+                {
+                  "id": 12263,
+                  "name": "Table 32",
+                  "slug": "table-32"
+                },
+                {
+                  "id": 12264,
+                  "name": "Table 33",
+                  "slug": "table-33"
+                },
+                {
+                  "id": 12265,
+                  "name": "Table 34",
+                  "slug": "table-34"
+                }
+              ]
+            }
+          ],
+          "secondary_display_active": false,
+          "secondary_display_capacity": null
+        },
+        "seeding_unit_capacity": 1476,
+        "system": "None"
+      },
+      "relationships": {
+        "sub_zones": {
+          "meta": {
+            "included": false
+          }
+        },
+        "stage": {
+          "data": {
+            "id": "1068",
+            "type": "stages"
+          }
+        },
+        "sub_stage": {
+          "data": {
+            "id": "24",
+            "type": "sub_stages"
+          }
+        },
+        "seeding_unit": {
+          "data": {
+            "id": "3601",
+            "type": "seeding_units"
+          }
+        }
+      }
+    },
+    {
+      "id": "24",
+      "type": "sub_stages",
+      "attributes": {
+        "id": 24,
+        "name": "Vegetation",
+        "position": 1
+      },
+      "relationships": {
+        "stage": {
+          "data": {
+            "id": "1068",
+            "type": "stages"
+          }
+        },
+        "zones": {
+          "meta": {
+            "included": false
+          }
+        }
+      }
     }
   ],
   "jsonapi": {

--- a/spec/support/data/api/completions/762428-clone-preprinted.json
+++ b/spec/support/data/api/completions/762428-clone-preprinted.json
@@ -1,9 +1,9 @@
 {
   "data": {
-    "id": "762429",
+    "id": "762428",
     "type": "completions",
     "attributes": {
-      "id": 762429,
+      "id": 762428,
       "status": "active",
       "user_id": 1772,
       "content": null,
@@ -76,7 +76,7 @@
         },
         "completion": {
           "data": {
-            "id": "762429",
+            "id": "762428",
             "type": "completions"
           }
         },
@@ -122,7 +122,7 @@
       "type": "sub_stages",
       "attributes": {
         "id": 24,
-        "name": "Flowering",
+        "name": "Clone",
         "position": 1
       },
       "relationships": {

--- a/spec/support/data/api/completions/762428-curing-preprinted.json
+++ b/spec/support/data/api/completions/762428-curing-preprinted.json
@@ -1,9 +1,9 @@
 {
   "data": {
-    "id": "762429",
+    "id": "762428",
     "type": "completions",
     "attributes": {
-      "id": 762429,
+      "id": 762428,
       "status": "active",
       "user_id": 1772,
       "content": null,
@@ -76,7 +76,7 @@
         },
         "completion": {
           "data": {
-            "id": "762429",
+            "id": "762428",
             "type": "completions"
           }
         },
@@ -122,7 +122,7 @@
       "type": "sub_stages",
       "attributes": {
         "id": 24,
-        "name": "Flowering",
+        "name": "Curing",
         "position": 1
       },
       "relationships": {

--- a/spec/support/data/api/completions/762428-drying-preprinted.json
+++ b/spec/support/data/api/completions/762428-drying-preprinted.json
@@ -1,9 +1,9 @@
 {
   "data": {
-    "id": "762429",
+    "id": "762428",
     "type": "completions",
     "attributes": {
-      "id": 762429,
+      "id": 762428,
       "status": "active",
       "user_id": 1772,
       "content": null,
@@ -76,7 +76,7 @@
         },
         "completion": {
           "data": {
-            "id": "762429",
+            "id": "762428",
             "type": "completions"
           }
         },
@@ -122,7 +122,7 @@
       "type": "sub_stages",
       "attributes": {
         "id": 24,
-        "name": "Flowering",
+        "name": "Drying",
         "position": 1
       },
       "relationships": {

--- a/spec/support/data/api/completions/762428-flowering-no-seeding.json
+++ b/spec/support/data/api/completions/762428-flowering-no-seeding.json
@@ -1,9 +1,9 @@
 {
   "data": {
-    "id": "762429",
+    "id": "762428",
     "type": "completions",
     "attributes": {
-      "id": 762429,
+      "id": 762428,
       "status": "active",
       "user_id": 1772,
       "content": null,
@@ -22,7 +22,7 @@
         "arbitrary_id": "Mar30-Lav-Cak-M0102",
         "crop_variety_id": 19278,
         "seeding_unit_id": 3591,
-        "zone_name": "Mothers [Flowering]"
+        "zone_name": "Mothers"
       }
     },
     "relationships": {
@@ -59,64 +59,6 @@
     }
   },
   "included": [
-    {
-      "id": "425818",
-      "type": "crop_batch_states",
-      "attributes": {
-        "harvest_quantity": null,
-        "id": 425818,
-        "quantity": 100
-      },
-      "relationships": {
-        "crop_batch": {
-          "data": {
-            "id": "105681",
-            "type": "crop_batches"
-          }
-        },
-        "completion": {
-          "data": {
-            "id": "762429",
-            "type": "completions"
-          }
-        },
-        "zone": {
-          "data": {
-            "id": "7249",
-            "type": "zones"
-          }
-        },
-        "sub_zone": {
-          "data": {
-            "id": "",
-            "type": "sub_zones"
-          }
-        },
-        "seeding_unit": {
-          "data": {
-            "id": "3591",
-            "type": "seeding_units"
-          }
-        },
-        "harvest_unit": {
-          "data": {
-            "id": "",
-            "type": "harvest_units"
-          }
-        }
-      }
-    },
-    {
-      "id": "3591",
-      "type": "seeding_units",
-      "attributes": {
-        "id": 3591,
-        "name": "plants",
-        "secondary_display_active": false,
-        "secondary_display_capacity": null,
-        "item_tracking_method": "preprinted"
-      }
-    },
     {
       "id": "24",
       "type": "sub_stages",

--- a/spec/support/data/api/completions/762428-flowering-preprinted.json
+++ b/spec/support/data/api/completions/762428-flowering-preprinted.json
@@ -116,6 +116,28 @@
         "secondary_display_capacity": null,
         "item_tracking_method": "preprinted"
       }
+    },
+    {
+      "id": "24",
+      "type": "sub_stages",
+      "attributes": {
+        "id": 24,
+        "name": "Flowering",
+        "position": 1
+      },
+      "relationships": {
+        "stage": {
+          "data": {
+            "id": "1068",
+            "type": "stages"
+          }
+        },
+        "zones": {
+          "meta": {
+            "included": false
+          }
+        }
+      }
     }
   ],
   "jsonapi": {

--- a/spec/support/data/api/completions/762428-no-seeding.json
+++ b/spec/support/data/api/completions/762428-no-seeding.json
@@ -58,6 +58,30 @@
       }
     }
   },
+  "included": [
+    {
+      "id": "24",
+      "type": "sub_stages",
+      "attributes": {
+        "id": 24,
+        "name": "Clones",
+        "position": 1
+      },
+      "relationships": {
+        "stage": {
+          "data": {
+            "id": "1068",
+            "type": "stages"
+          }
+        },
+        "zones": {
+          "meta": {
+            "included": false
+          }
+        }
+      }
+    }
+  ],
   "jsonapi": {
     "version": "1.0"
   }

--- a/spec/support/data/api/completions/762428-no-substage-no-seeding.json
+++ b/spec/support/data/api/completions/762428-no-substage-no-seeding.json
@@ -1,9 +1,9 @@
 {
   "data": {
-    "id": "762429",
+    "id": "762428",
     "type": "completions",
     "attributes": {
-      "id": 762429,
+      "id": 762428,
       "status": "active",
       "user_id": 1772,
       "content": null,
@@ -58,30 +58,6 @@
       }
     }
   },
-  "included": [
-    {
-      "id": "24",
-      "type": "sub_stages",
-      "attributes": {
-        "id": 24,
-        "name": "Clones",
-        "position": 1
-      },
-      "relationships": {
-        "stage": {
-          "data": {
-            "id": "1068",
-            "type": "stages"
-          }
-        },
-        "zones": {
-          "meta": {
-            "included": false
-          }
-        }
-      }
-    }
-  ],
   "jsonapi": {
     "version": "1.0"
   }

--- a/spec/support/data/api/completions/762428-vegetative-no-seeding.json
+++ b/spec/support/data/api/completions/762428-vegetative-no-seeding.json
@@ -1,9 +1,9 @@
 {
   "data": {
-    "id": "762429",
+    "id": "762428",
     "type": "completions",
     "attributes": {
-      "id": 762429,
+      "id": 762428,
       "status": "active",
       "user_id": 1772,
       "content": null,
@@ -22,7 +22,7 @@
         "arbitrary_id": "Mar30-Lav-Cak-M0102",
         "crop_variety_id": 19278,
         "seeding_unit_id": 3591,
-        "zone_name": "Mothers [Flowering]"
+        "zone_name": "Mothers"
       }
     },
     "relationships": {
@@ -60,69 +60,11 @@
   },
   "included": [
     {
-      "id": "425818",
-      "type": "crop_batch_states",
-      "attributes": {
-        "harvest_quantity": null,
-        "id": 425818,
-        "quantity": 100
-      },
-      "relationships": {
-        "crop_batch": {
-          "data": {
-            "id": "105681",
-            "type": "crop_batches"
-          }
-        },
-        "completion": {
-          "data": {
-            "id": "762429",
-            "type": "completions"
-          }
-        },
-        "zone": {
-          "data": {
-            "id": "7249",
-            "type": "zones"
-          }
-        },
-        "sub_zone": {
-          "data": {
-            "id": "",
-            "type": "sub_zones"
-          }
-        },
-        "seeding_unit": {
-          "data": {
-            "id": "3591",
-            "type": "seeding_units"
-          }
-        },
-        "harvest_unit": {
-          "data": {
-            "id": "",
-            "type": "harvest_units"
-          }
-        }
-      }
-    },
-    {
-      "id": "3591",
-      "type": "seeding_units",
-      "attributes": {
-        "id": 3591,
-        "name": "plants",
-        "secondary_display_active": false,
-        "secondary_display_capacity": null,
-        "item_tracking_method": "preprinted"
-      }
-    },
-    {
       "id": "24",
       "type": "sub_stages",
       "attributes": {
         "id": 24,
-        "name": "Flowering",
+        "name": "Vegetative",
         "position": 1
       },
       "relationships": {

--- a/spec/support/data/api/completions/762429-clone-preprinted.json
+++ b/spec/support/data/api/completions/762429-clone-preprinted.json
@@ -122,7 +122,7 @@
       "type": "sub_stages",
       "attributes": {
         "id": 24,
-        "name": "Flowering",
+        "name": "Clone",
         "position": 1
       },
       "relationships": {

--- a/spec/support/data/api/completions/762429-curing-preprinted.json
+++ b/spec/support/data/api/completions/762429-curing-preprinted.json
@@ -122,7 +122,7 @@
       "type": "sub_stages",
       "attributes": {
         "id": 24,
-        "name": "Flowering",
+        "name": "Curing",
         "position": 1
       },
       "relationships": {

--- a/spec/support/data/api/completions/762429-drying-preprinted.json
+++ b/spec/support/data/api/completions/762429-drying-preprinted.json
@@ -122,7 +122,7 @@
       "type": "sub_stages",
       "attributes": {
         "id": 24,
-        "name": "Flowering",
+        "name": "Drying",
         "position": 1
       },
       "relationships": {

--- a/spec/support/data/api/completions/762429-no-substage-no-seeding.json
+++ b/spec/support/data/api/completions/762429-no-substage-no-seeding.json
@@ -58,30 +58,6 @@
       }
     }
   },
-  "included": [
-    {
-      "id": "24",
-      "type": "sub_stages",
-      "attributes": {
-        "id": 24,
-        "name": "Clones",
-        "position": 1
-      },
-      "relationships": {
-        "stage": {
-          "data": {
-            "id": "1068",
-            "type": "stages"
-          }
-        },
-        "zones": {
-          "meta": {
-            "included": false
-          }
-        }
-      }
-    }
-  ],
   "jsonapi": {
     "version": "1.0"
   }

--- a/spec/support/data/api/completions/762429-vegetative-preprinted.json
+++ b/spec/support/data/api/completions/762429-vegetative-preprinted.json
@@ -122,7 +122,7 @@
       "type": "sub_stages",
       "attributes": {
         "id": 24,
-        "name": "Flowering",
+        "name": "Vegetative",
         "position": 1
       },
       "relationships": {

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -7,7 +7,7 @@ module Helpers
     @artemis_client ||= ArtemisApi::Client.new(
       access_token: 'abc.def.ghi',
       refresh_token: '123abc',
-      expires_at: (Time.now + 2.days).to_i
+      expires_at: (Time.zone.now + 2.days).to_i
     )
   end
 


### PR DESCRIPTION
Pivotal ticket: https://www.pivotaltracker.com/story/show/174256620