### PR TITLE
Filter items for a wet weight harvest [Ref #175415933]

### DIFF
--- a/app/services/common/base.rb
+++ b/app/services/common/base.rb
@@ -23,7 +23,7 @@ module Common
       @relationships = ctx[:relationships]
       @completion_id = ctx[:id]
       @integration = integration
-      @attributes  = ctx[:attributes]
+      @attributes = ctx[:attributes]
       @facility_id = @relationships&.dig(:facility, :data, :id)
       @batch_id = @relationships&.dig(:batch, :data, :id)
       @artemis  = ArtemisService.new(@integration.account, @batch_id, @facility_id)

--- a/app/services/metrc_service/plant/discard.rb
+++ b/app/services/metrc_service/plant/discard.rb
@@ -44,22 +44,11 @@ module MetrcService
         discard_type = @attributes.dig('options', 'discard_type')
         reason       = reason_note
 
-        if discard_type == 'partial'
-          return @attributes.dig('options', 'barcode').map do |barcode|
-            {
-              Id: nil,
-              Label: barcode,
-              ReasonNote: reason,
-              ActualDate: discard.start_time
-            }
-          end
-        end
-
-        items = get_items(batch.seeding_unit.id)
-        items.map do |item|
+        # TODO: update to use content: items {id, barcode} once portal info is reliable.
+        @attributes.dig('options', 'barcode').map do |barcode|
           {
             Id: nil,
-            Label: item.relationships.dig('barcode', 'data', 'id'),
+            Label: barcode,
             ReasonNote: reason,
             ActualDate: discard.start_time
           }

--- a/app/services/metrc_service/plant/move.rb
+++ b/app/services/metrc_service/plant/move.rb
@@ -112,6 +112,7 @@ module MetrcService
       memoize :next_step
 
       def move_plants
+        # TODO: Filter items based on completion content
         payload = items.map do |item|
           {
             Id: nil,

--- a/app/services/metrc_service/resource/wet_weight.rb
+++ b/app/services/metrc_service/resource/wet_weight.rb
@@ -44,7 +44,7 @@ module MetrcService
       end
 
       def items
-        @items ||= get_items(seeding_unit_id)
+        @items ||= get_items(seeding_unit_id).select { |item| completion.content['crop_batch_item_ids'].include?(item.id) }
       end
 
       def seeding_unit_id

--- a/app/services/metrc_service/resource/wet_weight.rb
+++ b/app/services/metrc_service/resource/wet_weight.rb
@@ -44,7 +44,8 @@ module MetrcService
       end
 
       def items
-        @items ||= get_items(seeding_unit_id).select { |item| completion.content['crop_batch_item_ids'].include?(item.id) }
+        completion_item_ids = @attributes.dig('content', 'crop_batch_item_ids')
+        @items ||= get_items(seeding_unit_id).select { |item| completion_item_ids&.include?(item.id) }
       end
 
       def seeding_unit_id

--- a/spec/services/metrc_service/plant/discard_spec.rb
+++ b/spec/services/metrc_service/plant/discard_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe MetrcService::Plant::Discard do
       },
       attributes: {
         options: {
-          tracking_barcode: '1A4FF01000000220000010',
+          barcode: ['1A4060300003B01000000838'],
           note_content: 'And the only prescription is moar cow bell',
           calculated_quantity: '5'
         }
@@ -61,7 +61,7 @@ RSpec.describe MetrcService::Plant::Discard do
           },
           attributes: {
             options: {
-              tracking_barcode: '1A4FF01000000220000010',
+              barcode: ['1A4FF01000000220000010'],
               note_content: 'And the only prescription is moar cow bell'
             }
           },
@@ -96,7 +96,7 @@ RSpec.describe MetrcService::Plant::Discard do
           },
           attributes: {
             options: {
-              tracking_barcode: '1A4FF01000000220000010',
+              barcode: ['1A4FF010000002200000105', '1A4FF010000002200000104', '1A4FF010000002200000103'],
               note_content: 'And the only prescription is moar cow bell'
             }
           },
@@ -124,9 +124,6 @@ RSpec.describe MetrcService::Plant::Discard do
         stub_request(:get, "#{ENV['ARTEMIS_BASE_URI']}/api/v3/facilities/1568/completions/1001?include=action_result,crop_batch_state.seeding_unit,crop_batch_state.zone.sub_stage")
           .to_return(body: { data: { id: '1001', type: 'discards', attributes: { id: 1001, quantity: 5, options: { reason_type: 'disease', reason_description: nil }, start_time: '2019-10-25T00:00:00.000Z' }, relationships: { batch: { data: { id: '96258', type: 'batches' } }, completion: { meta: { included: false } } } } }.to_json)
 
-        stub_request(:get, "#{ENV['ARTEMIS_BASE_URI']}/api/v3/facilities/1568/batches/96182/items?filter[seeding_unit_id]=3479&include=barcodes,seeding_unit")
-          .to_return(body: { data: [{ id: '969664', type: 'items', attributes: { id: 969664, harvest_quantity: 0, secondary_harvest_quantity: 10.0, secondary_harvest_unit: 'Grams', harvest_unit: 'Grams' }, relationships: { barcode: { data: { id: '1A4FF010000002200000105', type: 'barcodes' } } } }, { id: '969663', type: 'items', attributes: { id: 969663, harvest_quantity: 0, secondary_harvest_quantity: 10.0, secondary_harvest_unit: 'Grams', harvest_unit: 'Grams' }, relationships: { barcode: { data: { id: '1A4FF010000002200000104', type: 'barcodes' } } } }, { id: '969662', type: 'items', attributes: { id: 969662, harvest_quantity: 0, secondary_harvest_quantity: 10.0, secondary_harvest_unit: 'Grams', harvest_unit: 'Grams' }, relationships: { barcode: { data: { id: '1A4FF010000002200000103', type: 'barcodes' } } } }] }.to_json)
-
         stub_request(:post, 'https://sandbox-api-md.metrc.com/plants/v1/destroyplants?licenseNumber=LIC-0001')
           .with(
             body: [{ Id: nil, Label: '1A4FF010000002200000105', ReasonNote: 'Not Specified', ActualDate: '2020-03-30T07:00:00.000Z' }, { Id: nil, Label: '1A4FF010000002200000104', ReasonNote: 'Not Specified', ActualDate: '2020-03-30T07:00:00.000Z' }, { Id: nil, Label: '1A4FF010000002200000103', ReasonNote: 'Not Specified', ActualDate: '2020-03-30T07:00:00.000Z' }].to_json,
@@ -151,7 +148,7 @@ RSpec.describe MetrcService::Plant::Discard do
           },
           attributes: {
             options: {
-              tracking_barcode: '1A4FF01000000220000010',
+              barcode: ['1A4060300003B01000000838'],
               note_content: 'And the only prescription is moar cow bell',
               calculated_quantity: '5'
             }
@@ -179,9 +176,6 @@ RSpec.describe MetrcService::Plant::Discard do
 
         stub_request(:get, "#{ENV['ARTEMIS_BASE_URI']}/api/v3/facilities/1568/completions/111436?include=action_result,crop_batch_state.seeding_unit,crop_batch_state.zone.sub_stage")
           .to_return(body: { data: { id: '111436', type: 'discards', attributes: { id: 111436, quantity: 5, options: { reason_type: 'disease', reason_description: nil }, start_time: '2019-10-25T00:00:00.000Z' }, relationships: { batch: { data: { id: '96258', type: 'batches' } }, completion: { meta: { included: false } } } } }.to_json)
-
-        stub_request(:get, "#{ENV['ARTEMIS_BASE_URI']}/api/v3/facilities/1568/batches/96182/items?filter[seeding_unit_id]=3479&include=barcodes,seeding_unit")
-          .to_return(body: { data: [{ id: '969664', type: 'items', attributes: { id: 969664, harvest_quantity: 0, secondary_harvest_quantity: 10.0, secondary_harvest_unit: 'Grams', harvest_unit: 'Grams' }, relationships: { barcode: { data: { id: '1A4FF010000002200000105', type: 'barcodes' } } } }, { id: '969663', type: 'items', attributes: { id: 969663, harvest_quantity: 0, secondary_harvest_quantity: 10.0, secondary_harvest_unit: 'Grams', harvest_unit: 'Grams' }, relationships: { barcode: { data: { id: '1A4FF010000002200000104', type: 'barcodes' } } } }, { id: '969662', type: 'items', attributes: { id: 969662, harvest_quantity: 0, secondary_harvest_quantity: 10.0, secondary_harvest_unit: 'Grams', harvest_unit: 'Grams' }, relationships: { barcode: { data: { id: '1A4FF010000002200000103', type: 'barcodes' } } } }] }.to_json)
 
         stub_request(:post, 'https://sandbox-api-md.metrc.com/plantbatches/v1/destroy?licenseNumber=LIC-0001')
           .with(
@@ -280,9 +274,6 @@ RSpec.describe MetrcService::Plant::Discard do
 
         stub_request(:get, "#{ENV['ARTEMIS_BASE_URI']}/api/v3/facilities/1568/completions/3000?include=action_result,crop_batch_state.seeding_unit,crop_batch_state.zone.sub_stage")
           .to_return(body: { data: { id: '111436', type: 'discards', attributes: { id: 111436, quantity: 5, options: { reason_type: 'disease', reason_description: 'Not enough cow bell' }, start_time: '2019-10-25T00:00:00.000Z' }, relationships: { batch: { data: { id: '96258', type: 'batches' } }, completion: { meta: { included: false } } } } }.to_json)
-
-        stub_request(:get, "#{ENV['ARTEMIS_BASE_URI']}/api/v3/facilities/1568/batches/96182/items?filter%5Bseeding_unit_id%5D=3479&include=barcodes,seeding_unit")
-          .to_return(body: { data: [{ id: '326515', type: 'items', attributes: { id: 326515, status: 'active' }, relationships: { barcode: { data: { id: '1A4060300003B01000000838', type: 'barcodes' } }, seeding_unit: { data: { id: '100', type: 'seeding_units' } } } }] }.to_json)
       end
 
       subject { described_class.new(ctx, integration) }

--- a/spec/services/metrc_service/resource/wet_weight_spec.rb
+++ b/spec/services/metrc_service/resource/wet_weight_spec.rb
@@ -12,6 +12,9 @@ RSpec.describe MetrcService::Resource::WetWeight do
         action_result: { data: { id: 200 } }
       },
       attributes: {
+        content: {
+          crop_batch_item_ids: [969664, 969663, 969662]
+        },
         action_type: 'generate',
         options: {
           resource_unit_id: 297,
@@ -24,74 +27,86 @@ RSpec.describe MetrcService::Resource::WetWeight do
   end
 
   describe '#call' do
-    let(:expected_payload) do
-      [
-        {
-          DryingLocation: 'Room',
-          PatientLicenseNumber: nil,
-          ActualDate: nil,
-          Plant: '1A4FF010000002200000105',
-          Weight: 0.0,
-          UnitOfWeight: 'Grams',
-          HarvestName: 'Oct1-Ban-Spl-Can'
-        },
-        {
-          DryingLocation: 'Room',
-          PatientLicenseNumber: nil,
-          ActualDate: nil,
-          Plant: '1A4FF010000002200000104',
-          Weight: 0.0,
-          UnitOfWeight: 'Grams',
-          HarvestName: 'Oct1-Ban-Spl-Can'
-        },
-        {
-          DryingLocation: 'Room',
-          PatientLicenseNumber: nil,
-          ActualDate: nil,
-          Plant: '1A4FF010000002200000103',
-          Weight: 0.0,
-          UnitOfWeight: 'Grams',
-          HarvestName: 'Oct1-Ban-Spl-Can'
-        }
-      ]
-    end
-    subject { described_class.call(ctx, integration) }
+    context 'with removed items on batch' do
+      let(:expected_payload) do
+        [
+          {
+            DryingLocation: 'Room',
+            PatientLicenseNumber: nil,
+            ActualDate: nil,
+            Plant: '1A4FF010000002200000105',
+            Weight: 0.0,
+            UnitOfWeight: 'Grams',
+            HarvestName: 'Oct1-Ban-Spl-Can'
+          },
+          {
+            DryingLocation: 'Room',
+            PatientLicenseNumber: nil,
+            ActualDate: nil,
+            Plant: '1A4FF010000002200000104',
+            Weight: 0.0,
+            UnitOfWeight: 'Grams',
+            HarvestName: 'Oct1-Ban-Spl-Can'
+          },
+          {
+            DryingLocation: 'Room',
+            PatientLicenseNumber: nil,
+            ActualDate: nil,
+            Plant: '1A4FF010000002200000103',
+            Weight: 0.0,
+            UnitOfWeight: 'Grams',
+            HarvestName: 'Oct1-Ban-Spl-Can'
+          }
+        ]
+      end
+      subject { described_class.call(ctx, integration) }
 
-    before do
-      stub_request(:get, "#{ENV['ARTEMIS_BASE_URI']}/api/v3/facilities/1568")
-        .to_return(body: { data: { id: '1568', type: 'facilities', attributes: { id: 1568, name: 'Rare Dankness' } } }.to_json)
+      before do
+        stub_request(:get, "#{ENV['ARTEMIS_BASE_URI']}/api/v3/facilities/1568")
+          .to_return(body: { data: { id: '1568', type: 'facilities', attributes: { id: 1568, name: 'Rare Dankness' } } }.to_json)
 
-      stub_request(:get, "#{ENV['ARTEMIS_BASE_URI']}/api/v3/facilities/1568/batches/2002")
-        .to_return(body: { data: { id: '96182', type: 'batches', attributes: { id: 96182, arbitrary_id: 'Oct1-Ban-Spl-Can', start_type: 'seed', quantity: 0, harvest_quantity: nil, expected_harvest_at: '2019-10-04', harvested_at: nil, seeded_at: '2019-10-01', completed_at: '2019-10-04T16:00:00.000Z', facility_id: 1568, zone_name: 'Flowering', crop_variety: 'Banana Split', crop: 'Cannabis' }, relationships: { harvests: { meta: { included: false } }, completions: { meta: { included: false } }, items: { meta: { included: false } }, custom_data: { meta: { included: false } }, barcodes: { data: [{ type: :barcodes, id: '1A4060300003B01000000838' }] }, discards: { meta: { included: false } }, seeding_unit: { data: { type: 'seeding_units', id: '3479' } }, harvest_unit: { meta: { included: false } }, zone: { data: { id: 6425, type: 'zones' } }, sub_zone: { meta: { included: false } } } }, included: [{ id: '3479', type: 'seeding_units', attributes: { id: 3479, name: 'Plant (barcoded)', secondary_display_active: nil, secondary_display_capacity: nil, item_tracking_method: nil } }] }.to_json)
+        stub_request(:get, "#{ENV['ARTEMIS_BASE_URI']}/api/v3/facilities/1568/batches/2002")
+          .to_return(body: { data: { id: '96182', type: 'batches', attributes: { id: 96182, arbitrary_id: 'Oct1-Ban-Spl-Can', start_type: 'seed', quantity: 0, harvest_quantity: nil, expected_harvest_at: '2019-10-04', harvested_at: nil, seeded_at: '2019-10-01', completed_at: '2019-10-04T16:00:00.000Z', facility_id: 1568, zone_name: 'Flowering', crop_variety: 'Banana Split', crop: 'Cannabis' }, relationships: { harvests: { meta: { included: false } }, completions: { meta: { included: false } }, items: { meta: { included: false } }, custom_data: { meta: { included: false } }, barcodes: { data: [{ type: :barcodes, id: '1A4060300003B01000000838' }] }, discards: { meta: { included: false } }, seeding_unit: { data: { type: 'seeding_units', id: '3479' } }, harvest_unit: { meta: { included: false } }, zone: { data: { id: 6425, type: 'zones' } }, sub_zone: { meta: { included: false } } } }, included: [{ id: '3479', type: 'seeding_units', attributes: { id: 3479, name: 'Plant (barcoded)', secondary_display_active: nil, secondary_display_capacity: nil, item_tracking_method: nil } }] }.to_json)
 
-      stub_request(:get, "#{ENV['ARTEMIS_BASE_URI']}/api/v3/facilities/1568/batches/2002?include=zone,zone.sub_stage,barcodes,custom_data,seeding_unit,harvest_unit,sub_zone,custom_data.custom_field")
-        .to_return(body: { data: { id: '96182', type: 'batches', attributes: { id: 96182, arbitrary_id: 'Oct1-Ban-Spl-Can', start_type: 'seed', quantity: 0, harvest_quantity: nil, expected_harvest_at: '2019-10-04', harvested_at: nil, seeded_at: '2019-10-01', completed_at: '2019-10-04T16:00:00.000Z', facility_id: 1568, zone_name: 'Flowering', crop_variety: 'Banana Split', crop: 'Cannabis' }, relationships: { harvests: { meta: { included: false } }, completions: { meta: { included: false } }, items: { meta: { included: false } }, custom_data: { meta: { included: false } }, barcodes: { data: [{ type: :barcodes, id: '1A4060300003B01000000838' }] }, discards: { meta: { included: false } }, seeding_unit: { data: { type: 'seeding_units', id: '3479' } }, harvest_unit: { meta: { included: false } }, zone: { data: { id: 6425, type: 'zones' } }, sub_zone: { meta: { included: false } } } }, included: [{ id: '3479', type: 'seeding_units', attributes: { id: 3479, name: 'Plant (barcoded)', secondary_display_active: nil, secondary_display_capacity: nil, item_tracking_method: nil } }] }.to_json)
+        stub_request(:get, "#{ENV['ARTEMIS_BASE_URI']}/api/v3/facilities/1568/batches/2002?include=zone,zone.sub_stage,barcodes,custom_data,seeding_unit,harvest_unit,sub_zone,custom_data.custom_field")
+          .to_return(body: { data: { id: '96182', type: 'batches', attributes: { id: 96182, arbitrary_id: 'Oct1-Ban-Spl-Can', start_type: 'seed', quantity: 0, harvest_quantity: nil, expected_harvest_at: '2019-10-04', harvested_at: nil, seeded_at: '2019-10-01', completed_at: '2019-10-04T16:00:00.000Z', facility_id: 1568, zone_name: 'Flowering', crop_variety: 'Banana Split', crop: 'Cannabis' }, relationships: { harvests: { meta: { included: false } }, completions: { meta: { included: false } }, items: { meta: { included: false } }, custom_data: { meta: { included: false } }, barcodes: { data: [{ type: :barcodes, id: '1A4060300003B01000000838' }] }, discards: { meta: { included: false } }, seeding_unit: { data: { type: 'seeding_units', id: '3479' } }, harvest_unit: { meta: { included: false } }, zone: { data: { id: 6425, type: 'zones' } }, sub_zone: { meta: { included: false } } } }, included: [{ id: '3479', type: 'seeding_units', attributes: { id: 3479, name: 'Plant (barcoded)', secondary_display_active: nil, secondary_display_capacity: nil, item_tracking_method: nil } }] }.to_json)
 
-      stub_request(:get, "#{ENV['ARTEMIS_BASE_URI']}/api/v3/facilities/1568/resource_units?include=crop_variety")
-        .to_return(body: { data: [{ id: '99', type: 'resource_units', attributes: { id: 99, conversion_si: 1.0, kind: 'weight', name: 'g Wet Weight - Banana Split', unit_name: 'Gram', product_modifier: 'Wet Weight', options: { } }, relationships: { crop_variety: { data: { type: 'crop_varieties', id: 1 } } } }, { id: '100', type: 'resource_units', attributes: { id: 100, conversion_si: 1.0, kind: 'weight', name: 'g Waste - Banana Split', unit_name: 'Gram', product_modifier: 'Wet Waste', options: {} }, relationships: { crop_variety: { data: { type: 'crop_varieties', id: 1 } } } }], included: [{ type: 'crop_varieties', id: 1, attributes: { name: 'Banana Split' } }] }.to_json)
+        stub_request(:get, "#{ENV['ARTEMIS_BASE_URI']}/api/v3/facilities/1568/resource_units?include=crop_variety")
+          .to_return(body: { data: [{ id: '99', type: 'resource_units', attributes: { id: 99, conversion_si: 1.0, kind: 'weight', name: 'g Wet Weight - Banana Split', unit_name: 'Gram', product_modifier: 'Wet Weight', options: { } }, relationships: { crop_variety: { data: { type: 'crop_varieties', id: 1 } } } }, { id: '100', type: 'resource_units', attributes: { id: 100, conversion_si: 1.0, kind: 'weight', name: 'g Waste - Banana Split', unit_name: 'Gram', product_modifier: 'Wet Waste', options: {} }, relationships: { crop_variety: { data: { type: 'crop_varieties', id: 1 } } } }], included: [{ type: 'crop_varieties', id: 1, attributes: { name: 'Banana Split' } }] }.to_json)
 
-      stub_request(:get, "#{ENV['ARTEMIS_BASE_URI']}/api/v3/facilities/1568/completions?filter%5Bcrop_batch_ids%5D%5B0%5D=96182")
-        .to_return(body: { data: [{ id: '652633', type: 'completions', attributes: { id: 652633, user_id: 1598, content: nil, start_time: '2019-10-01T16: 00: 00.000Z', end_time: '2019-10-01T16: 00: 00.000Z', occurrence: nil, action_type: 'batch', options: { zone_id: 6422, quantity: '5', arbitrary_id: 'Oct1-Ban-Spl-Can', growth_cycle_id: 11417, seeding_unit_id: 3479, tracking_barcode: '1A4FF01000000220000010', arbitrary_id_base: 'Ban-Spl-Can' } }, relationships: { action_result: { data: { id: 96182, type: 'CropBatch' } }, batch: { data: { id: '96182', type: 'batches' } }, facility: { data: { id: 1568, type: 'facilities' } }, user: { data: { id: 1598, type: 'users' } } } }] }.to_json)
+        stub_request(:get, "#{ENV['ARTEMIS_BASE_URI']}/api/v3/facilities/1568/completions?filter%5Bcrop_batch_ids%5D%5B0%5D=96182")
+          .to_return(body:
+            { data: [{ id: '652633', type: 'completions', attributes: { id: 652633, user_id: 1598, content: nil, start_time: '2019-10-01T16: 00: 00.000Z', end_time: '2019-10-01T16: 00: 00.000Z', occurrence: nil, action_type: 'batch', options: { zone_id: 6422, quantity: '5', arbitrary_id: 'Oct1-Ban-Spl-Can', growth_cycle_id: 11417, seeding_unit_id: 3479, tracking_barcode: '1A4FF01000000220000010', arbitrary_id_base: 'Ban-Spl-Can' } }, relationships: { action_result: { data: { id: 96182, type: 'CropBatch' } }, batch: { data: { id: '96182', type: 'batches' } }, facility: { data: { id: 1568, type: 'facilities' } }, user: { data: { id: 1598, type: 'users' } } } }] }.to_json)
 
-      stub_request(:get, "#{ENV['ARTEMIS_BASE_URI']}/api/v3/facilities/1568/batches/96182/items?filter[seeding_unit_id]&include=barcodes,seeding_unit")
-        .to_return(body: { data: [{ id: '969664', type: 'items', attributes: { id: 969664, harvest_quantity: 0, secondary_harvest_quantity: 10.0, secondary_harvest_unit: 'Grams', harvest_unit: 'Grams' }, relationships: { barcode: { data: { id: '1A4FF010000002200000105', type: 'barcodes' } } } }, { id: '969663', type: 'items', attributes: { id: 969663, harvest_quantity: 0, secondary_harvest_quantity: 10.0, secondary_harvest_unit: 'Grams', harvest_unit: 'Grams' }, relationships: { barcode: { data: { id: '1A4FF010000002200000104', type: 'barcodes' } } } }, { id: '969662', type: 'items', attributes: { id: 969662, harvest_quantity: 0, secondary_harvest_quantity: 10.0, secondary_harvest_unit: 'Grams', harvest_unit: 'Grams' }, relationships: { barcode: { data: { id: '1A4FF010000002200000103', type: 'barcodes' } } } }] }.to_json)
+        stub_request(:get, "#{ENV['ARTEMIS_BASE_URI']}/api/v3/facilities/1568/batches/96182/items?filter[seeding_unit_id]&include=barcodes,seeding_unit")
+          .to_return(body: {
+            data:[
+              { id: '969664', type: 'items', attributes: { id: 969664, harvest_quantity: 0, secondary_harvest_quantity: 10.0, secondary_harvest_unit: 'Grams', harvest_unit: 'Grams' }, relationships: { barcode: { data: { id: '1A4FF010000002200000105', type: 'barcodes' } } } },
+              { id: '969663', type: 'items', attributes: { id: 969663, harvest_quantity: 0, secondary_harvest_quantity: 10.0, secondary_harvest_unit: 'Grams', harvest_unit: 'Grams' }, relationships: { barcode: { data: { id: '1A4FF010000002200000104', type: 'barcodes' } } } },
+              { id: '969662', type: 'items', attributes: { id: 969662, harvest_quantity: 0, secondary_harvest_quantity: 10.0, secondary_harvest_unit: 'Grams', harvest_unit: 'Grams' }, relationships: { barcode: { data: { id: '1A4FF010000002200000103', type: 'barcodes' } } } },
+              { id: '969700', type: 'items', attributes: { id: 969700, harvest_quantity: 0, secondary_harvest_quantity: 10.0, secondary_harvest_unit: 'Grams', harvest_unit: 'Grams', status: 'removed'}, relationships: { barcode: { data: { id: '1A4FF010000002200000103', type: 'barcodes' } } } },
+              { id: '969701', type: 'items', attributes: { id: 969701, harvest_quantity: 0, secondary_harvest_quantity: 10.0, secondary_harvest_unit: 'Grams', harvest_unit: 'Grams', status: 'removed' }, relationships: { barcode: { data: { id: '1A4FF010000002200000103', type: 'barcodes' } } } }
+            ] }.to_json)
 
-      stub_request(:get, "#{ENV['ARTEMIS_BASE_URI']}/api/v3/zones/6425")
-        .to_return(body: { data: { id: '6425', type: 'zones', attributes: { id: 6425, name: 'Room' } } }.to_json)
+        stub_request(:get, "#{ENV['ARTEMIS_BASE_URI']}/api/v3/zones/6425")
+          .to_return(body: {
+            data: { id: '6425', type: 'zones', attributes: { id: 6425, name: 'Room' } }
+          }.to_json)
 
-      stub_request(:get, "#{ENV['ARTEMIS_BASE_URI']}/api/v3/facilities/1568/resource_units/?include=crop_variety")
-        .to_return(status: 200, body: load_response_json('api/sync/facilities/1/resource_units'))
+        stub_request(:get, "#{ENV['ARTEMIS_BASE_URI']}/api/v3/facilities/1568/resource_units/?include=crop_variety")
+          .to_return(status: 200, body: load_response_json('api/sync/facilities/1/resource_units'))
 
-      stub_request(:get, "#{ENV['ARTEMIS_BASE_URI']}/api/v3/facilities/1568/resource_units/297?include=crop_variety")
-        .to_return(status: 200, body: load_response_json('api/sync/facilities/1/resource_units/8'))
+        stub_request(:get, "#{ENV['ARTEMIS_BASE_URI']}/api/v3/facilities/1568/resource_units/297?include=crop_variety")
+          .to_return(status: 200, body: load_response_json('api/sync/facilities/1/resource_units/8'))
 
-      stub_request(:post, 'https://sandbox-api-md.metrc.com/plants/v1/harvestplants?licenseNumber=LIC-0001')
-        .with(body: expected_payload.to_json)
-        .to_return(status: 200, body: '', headers: {})
-    end
+        stub_request(:post, 'https://sandbox-api-md.metrc.com/plants/v1/harvestplants?licenseNumber=LIC-0001')
+          .with(body: expected_payload.to_json)
+          .to_return(status: 200, body: '', headers: {})
+      end
 
-    it 'is successful' do
-      expect(subject).to be_success
+      it 'is successful with active items' do
+        expect(subject).to be_success
+      end
     end
   end
 end


### PR DESCRIPTION
The `get_items()` call retrieves all items from a batch at the time the request is made. 
Instead, we want items relevant to the completion. 

Similarly for discards we only want to use barcodes associated with the completion.