### PR TITLE
Use actual state to check if arbitrary id is allowed rather than mapping to CO

### DIFF
--- a/app/services/common/base.rb
+++ b/app/services/common/base.rb
@@ -113,7 +113,7 @@ module Common
       raise InvalidAttributes, "Missing barcode for batch '#{batch.arbitrary_id}'" if barcodes.blank?
 
       matches = barcodes&.select { |label| /[A-Z0-9]{24,24}(-split)?/.match?(label) }&.sort
-      arbitrary_id_allowed = STATES_WITH_ARBITRARY_BATCH_ID.include?(state&.to_sym)
+      arbitrary_id_allowed = STATES_WITH_ARBITRARY_BATCH_ID.include?(@integration.state.to_sym)
 
       # In some states, you can send our batch
       # arbitrary ID instead of a Metrc tag


### PR DESCRIPTION
MT and MA were being mapped to CO but the check for if arbitrary id is allowed is using MA no CO hence failing to allow a batch tag to be the arbitrary id