### PR TITLE
Fix moves unable to find previous stage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,8 +10,8 @@ jobs:
           name: Restore node_modules from cache
           key: node_modules-v1-{{ checksum "yarn.lock" }}
       - add_ssh_keys:
-            fingerprints:
-              - '94:83:95:15:e6:c9:0b:53:7f:a7:a2:47:9e:dc:55:70'
+          fingerprints:
+            - "94:83:95:15:e6:c9:0b:53:7f:a7:a2:47:9e:dc:55:70"
       - run: yarn install --check-files
 
       - save_cache:
@@ -82,7 +82,7 @@ jobs:
     docker:
       - image: circleci/ruby:2.6.6-node-browsers
         environment:
-          AGRILYST_URL: 'test.com'
+          AGRILYST_URL: "test.com"
           DATABASE_URL: postgres://postgres@localhost/cannapi_test
           RAILS_ENV: test
           BULLET: true
@@ -125,7 +125,7 @@ jobs:
 
       - run:
           name: Run Unit Tests
-          command: bin/bundle exec rspec --out=/tmp/test-results
+          command: bin/bundle exec rspec
 
       - store_test_results:
           path: /tmp/test-results

--- a/app/services/artemis_service.rb
+++ b/app/services/artemis_service.rb
@@ -20,7 +20,7 @@ class ArtemisService
   end
 
   def get_completion(id, add = 'action_result,crop_batch_state.seeding_unit,crop_batch_state.zone.sub_stage')
-    get_batch.completion(id, include: add)
+    @artemis.find_one('completions', id, facility_id: get_facility.id, include: add, force: true)
   end
 
   def get_items(seeding_unit_id, include: 'barcodes,seeding_unit')

--- a/app/services/artemis_service.rb
+++ b/app/services/artemis_service.rb
@@ -16,7 +16,7 @@ class ArtemisService
   end
 
   def get_batch_by_id(id, add = 'zone,zone.sub_stage,barcodes,custom_data,seeding_unit,harvest_unit,sub_zone,custom_data.custom_field')
-    get_facility.batch(id, include: add, force: true)
+    get_facility.batch(id, include: add)
   end
 
   def get_completion(id, add = 'action_result,crop_batch_state.seeding_unit,crop_batch_state.zone.sub_stage')

--- a/app/services/artemis_service.rb
+++ b/app/services/artemis_service.rb
@@ -16,7 +16,7 @@ class ArtemisService
   end
 
   def get_batch_by_id(id, add = 'zone,zone.sub_stage,barcodes,custom_data,seeding_unit,harvest_unit,sub_zone,custom_data.custom_field')
-    get_facility.batch(id, include: add)
+    get_facility.batch(id, include: add, force: true)
   end
 
   def get_completion(id, add = 'action_result,crop_batch_state.seeding_unit,crop_batch_state.zone.sub_stage')

--- a/app/services/common/base.rb
+++ b/app/services/common/base.rb
@@ -107,7 +107,6 @@ module Common
     memoize :batch
 
     def batch_tag # rubocop:disable Metrics/PerceivedComplexity
-      debugger
       barcodes = batch.relationships.dig('barcodes', 'data')&.map { |label| label['id'] }
 
       raise InvalidAttributes, "Missing barcode for batch '#{batch.arbitrary_id}'" if barcodes.blank?

--- a/app/services/common/base.rb
+++ b/app/services/common/base.rb
@@ -107,6 +107,7 @@ module Common
     memoize :batch
 
     def batch_tag # rubocop:disable Metrics/PerceivedComplexity
+      debugger
       barcodes = batch.relationships.dig('barcodes', 'data')&.map { |label| label['id'] }
 
       raise InvalidAttributes, "Missing barcode for batch '#{batch.arbitrary_id}'" if barcodes.blank?

--- a/app/services/common/base_service_action.rb
+++ b/app/services/common/base_service_action.rb
@@ -1,5 +1,7 @@
 module Common
   class BaseServiceAction
+    extend Memoist
+
     DEFAULT_RUN_MODE = :later
 
     def self.call(*args, &block)

--- a/app/services/metrc_service/plant/move.rb
+++ b/app/services/metrc_service/plant/move.rb
@@ -1,7 +1,6 @@
 module MetrcService
   module Plant
     class Move < Base
-
       DEFAULT_MOVE_STEP = :change_growth_phase
 
       def call
@@ -66,7 +65,7 @@ module MetrcService
       memoize :next_step_name
 
       def next_step(previous_completion = nil, current_completion = nil) # rubocop:disable Metrics/PerceivedComplexity
-        return DEFAULT_MOVE_STEP if previous_completion.nil? || current_completion.nil?
+        return DEFAULT_MOVE_STEP if previous_completion.nil? || current_completion.nil? || current_completion.action_type == 'start'
 
         new_growth_phase = growth_phase_for_completion(current_completion)
         previous_growth_phase = growth_phase_for_completion(previous_completion)

--- a/app/services/metrc_service/plant/move.rb
+++ b/app/services/metrc_service/plant/move.rb
@@ -74,14 +74,14 @@ module MetrcService
         new_growth_phase = growth_phase_for_completion(current_completion)
         previous_growth_phase = growth_phase_for_completion(previous_completion)
 
-        return DEFAULT_MOVE_STEP if previous_growth_phase.nil? || new_growth_phase.nil?
-
         # Yeah, I don't like this either.
         previous_completion_had_barcodes = items_have_barcodes?(previous_completion.included&.dig(:seeding_units)&.first&.item_tracking_method)
         current_completion_has_barcodes  = items_have_barcodes?(current_completion.included&.dig(:seeding_units)&.first&.item_tracking_method)
         has_no_barcodes = !previous_completion_had_barcodes && !current_completion_has_barcodes
         moved_to_barcodes = !previous_completion_had_barcodes && current_completion_has_barcodes
         already_had_barcodes = previous_completion_had_barcodes && current_completion_has_barcodes
+
+        return DEFAULT_MOVE_STEP if previous_growth_phase.nil? || new_growth_phase.nil?
 
         return :move_plants if is_a_split? && already_had_barcodes
 

--- a/app/services/metrc_service/plant/start.rb
+++ b/app/services/metrc_service/plant/start.rb
@@ -10,6 +10,7 @@ module MetrcService
           transaction.update(type: :start_batch_from_package)
           create_plantings_from_package
         elsif source_plant
+          transaction.update(type: :start_batch_from_source_plant)
           create_plant_batch_from_mother
         else
           create_plant_batch

--- a/app/services/ncs_service/plant/move.rb
+++ b/app/services/ncs_service/plant/move.rb
@@ -48,7 +48,7 @@ module NcsService
       private
 
       def next_step_name
-        previous_completion = prior_move || prior_start
+        previous_completion = prior_move || start_completion
         return DEFAULT_MOVE_STEP if previous_completion.blank?
 
         previous_growth_phase = normalized_growth_phase(previous_completion.included&.dig(:sub_stages)&.first&.name)

--- a/app/services/ncs_service/plant/move.rb
+++ b/app/services/ncs_service/plant/move.rb
@@ -26,28 +26,24 @@ module NcsService
       end
 
       def prior_move
-        previous_move = batch.completions.select do |c|
-          c.action_type == 'move' && c.id < @completion_id
-        end.max_by(&:start_time)
+        previous_move = batch.completions.select { |c| c.action_type == 'move' && c.id < @completion_id }
+                             .max_by { |comp| [comp.start_time, comp.id] }
 
         return if previous_move.nil?
 
         # calling get_completion here will ensure relationships are side loaded.
         get_completion(previous_move&.id)
       end
-      memoize
+      memoize :prior_move
 
-      def prior_start
-        previous_start = batch.completions.select do |c|
-          c.action_type == 'start' && c.id < @completion_id
-        end.max_by(&:start_time)
-
-        return if previous_start.nil?
+      def start_completion
+        start = batch.completions.find { |comp| comp.action_type == 'start' }
+        return if start.nil?
 
         # calling get_completion here will ensure relationships are side loaded.
-        get_completion(previous_start&.id)
+        get_completion(start&.id)
       end
-      memoize
+      memoize :start_completion
 
       private
 

--- a/app/services/ncs_service/plant/move.rb
+++ b/app/services/ncs_service/plant/move.rb
@@ -26,8 +26,6 @@ module NcsService
       end
 
       def prior_move
-        return @prior_move if @prior_move
-
         previous_move = batch.completions.select do |c|
           c.action_type == 'move' && c.id < @completion_id
         end.max_by(&:start_time)
@@ -35,13 +33,11 @@ module NcsService
         return if previous_move.nil?
 
         # calling get_completion here will ensure relationships are side loaded.
-        @prior_move = get_completion(previous_move&.id)
+        get_completion(previous_move&.id)
       end
-      memoize :prior_move
+      memoize
 
       def prior_start
-        return @prior_start if @prior_start
-
         previous_start = batch.completions.select do |c|
           c.action_type == 'start' && c.id < @completion_id
         end.max_by(&:start_time)
@@ -49,9 +45,9 @@ module NcsService
         return if previous_start.nil?
 
         # calling get_completion here will ensure relationships are side loaded.
-        @prior_start = get_completion(previous_start&.id)
+        get_completion(previous_start&.id)
       end
-      memoize :prior_start
+      memoize
 
       private
 
@@ -118,7 +114,7 @@ module NcsService
       end
 
       def start_time
-        @attributes.dig('start_time')
+        @attributes['start_time']
       end
 
       def immature?

--- a/spec/services/metrc_service/plant/move_spec.rb
+++ b/spec/services/metrc_service/plant/move_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe MetrcService::Plant::Move do
     describe 'on an old successful transaction' do
       let(:transaction) { create(:transaction, :successful, :move, account: account, integration: integration) }
       let(:sub_stage) { double(:sub_stage, name: 'clone', attributes: { 'name': 'clone' }) }
-      let(:zone) { double(:zone, sub_stage: sub_stage)  }
+      let(:zone) { double(:zone, sub_stage: sub_stage) }
       let(:batch) { double(:batch, crop: 'Cannabis', zone: zone) }
 
       it { is_expected.to eq(transaction) }
@@ -68,9 +68,8 @@ RSpec.describe MetrcService::Plant::Move do
       end
     end
 
-    describe 'moving to vegetative phase' do
+    describe 'moving from vegetative to vegetative phase' do
       let(:seeding_unit_id) { 7 }
-      let(:previous_move) { create(:transaction, :successful, :move, account: account, integration: integration, batch_id: batch_id) }
       let(:expected_payload) do
         [{
           Name: 'ABCDEF1234567890ABCDEF01',
@@ -93,10 +92,16 @@ RSpec.describe MetrcService::Plant::Move do
           .to_return(body: load_response_json("api/sync/facilities/#{facility_id}/batches/#{batch_id}/items"))
 
         stub_request(:get, "#{ENV['ARTEMIS_BASE_URI']}/api/v3/facilities/#{facility_id}/completions/3000?include=action_result,crop_batch_state.seeding_unit,crop_batch_state.zone.sub_stage")
-          .to_return(body: load_response_json('api/completions/3000'))
+          .to_return(body: load_response_json('api/completions/3000-veg-move'))
 
-        stub_request(:get, "#{ENV['ARTEMIS_BASE_URI']}/api/v3/facilities/#{facility_id}/completions/#{previous_move.completion_id}?include=action_result,crop_batch_state.seeding_unit,crop_batch_state.zone.sub_stage")
-          .to_return(body: load_response_json('api/completions/3000'))
+        stub_request(:get, "#{ENV['ARTEMIS_BASE_URI']}/api/v3/facilities/#{facility_id}/completions?filter[crop_batch_ids][]=#{batch_id}")
+          .to_return(body: { data: [
+            { id: '2999', type: 'completions', attributes: { id: 2999, start_time: '2020-04-10T07:00:00.000Z', action_type: 'move' } },
+            { id: '3000', type: 'completions', attributes: { id: 3000, start_time: '2020-04-20T07:00:00.000Z', action_type: 'move' } }
+          ] }.to_json)
+
+        stub_request(:get, "#{ENV['ARTEMIS_BASE_URI']}/api/v3/facilities/#{facility_id}/completions/2999?include=action_result,crop_batch_state.seeding_unit,crop_batch_state.zone.sub_stage")
+          .to_return(body: load_response_json('api/completions/2999-veg-move'))
 
         stub_request(:get, "#{ENV['ARTEMIS_BASE_URI']}/api/v3/facilities/#{facility_id}/completions?filter%5Baction_type%5D=generate&filter%5Bparent_id%5D=3000")
           .to_return(body: { data: [] }.to_json)
@@ -106,7 +111,7 @@ RSpec.describe MetrcService::Plant::Move do
           .to_return(status: 200)
       end
 
-      it 'is successful' do
+      it 'is updates location successful' do
         expect_any_instance_of(MetrcService::Resource::WetWeight)
           .not_to receive(:harvest_plants)
 
@@ -114,10 +119,29 @@ RSpec.describe MetrcService::Plant::Move do
       end
     end
 
-    describe 'moving to flower phase' do
+    describe 'moving from flower to flower' do
       let(:batch_id) { 82 }
       let(:seeding_unit_id) { 7 }
-      let(:previous_move) { create(:transaction, :successful, :move, account: account, integration: integration, batch_id: batch_id) }
+      let(:ctx) do
+        {
+          id: 4000,
+          relationships: {
+            batch: { data: { id: batch_id } },
+            facility: { data: { id: 2 } }
+          },
+          attributes: {
+            start_time: '2020-04-15',
+            options: {
+              tracking_barcode: 'ABCDEF1234567890ABCDEF01',
+              note_content: 'And the only prescription is moar cow bell',
+              zone_name: 'Mothers [Flowering]',
+              seeding_unit_id: seeding_unit_id
+            }
+          },
+          completion_id: 4000
+        }.with_indifferent_access
+      end
+
       let(:expected_payload) do
         [{
           Name: 'ABCDEF1234567890ABCDEF01',
@@ -139,11 +163,17 @@ RSpec.describe MetrcService::Plant::Move do
         stub_request(:get, "#{ENV['ARTEMIS_BASE_URI']}/api/v3/facilities/#{facility_id}/batches/#{batch_id}/items?filter[seeding_unit_id]=#{seeding_unit_id}&include=barcodes,seeding_unit")
           .to_return(body: load_response_json("api/sync/facilities/#{facility_id}/batches/#{batch_id}/items"))
 
-        stub_request(:get, "#{ENV['ARTEMIS_BASE_URI']}/api/v3/facilities/#{facility_id}/completions/3000?include=action_result,crop_batch_state.seeding_unit,crop_batch_state.zone.sub_stage")
-          .to_return(body: load_response_json('api/completions/3000'))
+        stub_request(:get, "#{ENV['ARTEMIS_BASE_URI']}/api/v3/facilities/#{facility_id}/completions/4000?include=action_result,crop_batch_state.seeding_unit,crop_batch_state.zone.sub_stage")
+          .to_return(body: load_response_json('api/completions/4000-flower-move'))
 
-        stub_request(:get, "#{ENV['ARTEMIS_BASE_URI']}/api/v3/facilities/#{facility_id}/completions/#{previous_move.completion_id}?include=action_result,crop_batch_state.seeding_unit,crop_batch_state.zone.sub_stage")
-          .to_return(body: load_response_json('api/completions/3000'))
+        stub_request(:get, "#{ENV['ARTEMIS_BASE_URI']}/api/v3/facilities/#{facility_id}/completions?filter[crop_batch_ids][]=#{batch_id}")
+          .to_return(body: { data: [
+            { id: '3999', type: 'completions', attributes: { id: 3999, start_time: '2020-04-10T07:00:00.000Z', action_type: 'move' } },
+            { id: '4000', type: 'completions', attributes: { id: 4000, start_time: '2020-04-20T07:00:00.000Z', action_type: 'move' } }
+          ] }.to_json)
+
+        stub_request(:get, "#{ENV['ARTEMIS_BASE_URI']}/api/v3/facilities/#{facility_id}/completions/3999?include=action_result,crop_batch_state.seeding_unit,crop_batch_state.zone.sub_stage")
+          .to_return(body: load_response_json('api/completions/3999-flower-move'))
 
         stub_request(:get, "#{ENV['ARTEMIS_BASE_URI']}/api/v3/facilities/#{facility_id}/completions?filter%5Baction_type%5D=generate&filter%5Bparent_id%5D=3000")
           .to_return(body: { data: [] }.to_json)
@@ -187,7 +217,7 @@ RSpec.describe MetrcService::Plant::Move do
       end
     end
 
-    context 'with an unsopported growth phase' do
+    context 'with an unsupported growth phase' do
       let(:first_move) do
         response = create_response('api/completions/762428-no-substage-no-seeding')
         artemis_client.process_response(response, 'completions')
@@ -365,7 +395,7 @@ RSpec.describe MetrcService::Plant::Move do
           .to_return(body: load_response_json('api/sync/facilities/2/batches/84'))
 
         stub_request(:get, "#{ENV['ARTEMIS_BASE_URI']}/api/v3/facilities/2/completions/3000?include=action_result,crop_batch_state.seeding_unit,crop_batch_state.zone.sub_stage")
-          .to_return(body: load_response_json('api/completions/3000-move'))
+          .to_return(body: load_response_json('api/completions/3000-veg-move'))
 
         stub_request(:post, 'https://sandbox-api-md.metrc.com/plants/v1/moveplants?licenseNumber=LIC-0001')
           .with(body: expected_payload.to_json)
@@ -762,4 +792,29 @@ RSpec.describe MetrcService::Plant::Move do
       end
     end
   end
+
+  # describe '#prior_move' do
+  #   let(:facility_id) { 2 }
+  #   let(:batch_id) { 84 }
+  #   let(:start_transaction) { create(:transaction, :successful, :start, account: account, integration: integration, batch_id: batch_id, completion_id: 762428) }
+  #   subject { described_class.new(ctx, integration) }
+  #
+  #   before do
+  #     start_transaction
+  #
+  #     stub_request(:get, "#{ENV['ARTEMIS_BASE_URI']}/api/v3/facilities/#{facility_id}/completions?filter[crop_batch_ids][]=#{crop_batch_id}")
+  #       .to_return(body: { data: [
+  #         { id: '90210', type: 'completions', attributes: { id: 90210, start_time: '2020-03-30T07:00:00.000Z', action_type: 'start', parent_id: 90209 } },
+  #         { id: '90211', type: 'completions', attributes: { id: 90211, start_time: '2020-04-10T07:00:00.000Z', action_type: 'move', options: {} } },
+  #         { id: '90220', type: 'completions', attributes: { id: 90220, start_time: '2020-04-20T07:00:00.000Z', action_type: 'move', options: {} } }
+  #       ] }.to_json)
+  #   end
+  #
+  #   it 'returns most recent move completion' do
+  #   end
+  # end
+  # ArtemisApi::Completion.find_all(facility_id: facility_id,
+  #                                     client: client,
+  #                                     include: include,
+  #                                     filters: {crop_batch_ids: [id]}.with_indifferent_access.merge(filters))
 end

--- a/spec/services/metrc_service/plant/move_spec.rb
+++ b/spec/services/metrc_service/plant/move_spec.rb
@@ -96,8 +96,8 @@ RSpec.describe MetrcService::Plant::Move do
 
         stub_request(:get, "#{ENV['ARTEMIS_BASE_URI']}/api/v3/facilities/#{facility_id}/completions?filter[crop_batch_ids][]=#{batch_id}")
           .to_return(body: { data: [
-            { id: '2999', type: 'completions', attributes: { id: 2999, start_time: '2020-04-10T07:00:00.000Z', action_type: 'move' } },
-            { id: '3000', type: 'completions', attributes: { id: 3000, start_time: '2020-04-20T07:00:00.000Z', action_type: 'move' } }
+            JSON.parse(load_response_json('api/completions/2999-veg-move'))['data'],
+            JSON.parse(load_response_json('api/completions/3000-veg-move'))['data']
           ] }.to_json)
 
         stub_request(:get, "#{ENV['ARTEMIS_BASE_URI']}/api/v3/facilities/#{facility_id}/completions/2999?include=action_result,crop_batch_state.seeding_unit,crop_batch_state.zone.sub_stage")
@@ -168,8 +168,8 @@ RSpec.describe MetrcService::Plant::Move do
 
         stub_request(:get, "#{ENV['ARTEMIS_BASE_URI']}/api/v3/facilities/#{facility_id}/completions?filter[crop_batch_ids][]=#{batch_id}")
           .to_return(body: { data: [
-            { id: '3999', type: 'completions', attributes: { id: 3999, start_time: '2020-04-10T07:00:00.000Z', action_type: 'move' } },
-            { id: '4000', type: 'completions', attributes: { id: 4000, start_time: '2020-04-20T07:00:00.000Z', action_type: 'move' } }
+            JSON.parse(load_response_json('api/completions/3999-flower-move'))['data'],
+            JSON.parse(load_response_json('api/completions/4000-flower-move'))['data']
           ] }.to_json)
 
         stub_request(:get, "#{ENV['ARTEMIS_BASE_URI']}/api/v3/facilities/#{facility_id}/completions/3999?include=action_result,crop_batch_state.seeding_unit,crop_batch_state.zone.sub_stage")

--- a/spec/services/metrc_service/plant/start_spec.rb
+++ b/spec/services/metrc_service/plant/start_spec.rb
@@ -2,12 +2,14 @@ require 'rails_helper'
 
 RSpec.describe MetrcService::Plant::Start do
   let(:integration) { create(:integration, state: 'ca') }
+  let(:batch_id) { 2002 }
+  let(:facility_id) { 1568 }
   let(:ctx) do
     {
       id: 3000,
       relationships: {
-        batch: { data: { id: 2002 } },
-        facility: { data: { id: 1568 } }
+        batch: { data: { id: batch_id } },
+        facility: { data: { id: facility_id } }
       },
       attributes: {
         options: {
@@ -29,8 +31,8 @@ RSpec.describe MetrcService::Plant::Start do
         {
           id: 3000,
           relationships: {
-            batch: { data: { id: 2002 } },
-            facility: { data: { id: 1568 } }
+            batch: { data: { id: batch_id } },
+            facility: { data: { id: facility_id } }
           },
           attributes: {
             options: {
@@ -73,16 +75,16 @@ RSpec.describe MetrcService::Plant::Start do
         end
 
         before do
-          stub_request(:get, 'https://portal.artemisag.com/api/v3/facilities/1568')
-            .to_return(body: { data: { id: '1568', type: 'facilities', attributes: { id: 1568, name: 'Rare Dankness' } } }.to_json)
+          stub_request(:get, "https://portal.artemisag.com/api/v3/facilities/#{facility_id}")
+            .to_return(body: { data: { id: facility_id, type: 'facilities', attributes: { id: facility_id, name: 'Rare Dankness' } } }.to_json)
 
-          stub_request(:get, 'https://portal.artemisag.com/api/v3/facilities/1568/batches/2002?include=zone,zone.sub_stage,barcodes,custom_data,seeding_unit,harvest_unit,sub_zone,custom_data.custom_field')
+          stub_request(:get, "https://portal.artemisag.com/api/v3/facilities/#{facility_id}/batches/#{batch_id}?include=zone,zone.sub_stage,barcodes,custom_data,seeding_unit,harvest_unit,sub_zone,custom_data.custom_field")
             .to_return(body: {
               data: {
-                id: '2002',
+                id: batch_id,
                 type: 'batches',
                 attributes: {
-                  id: 2002,
+                  id: batch_id,
                   arbitrary_id: 'Jun19-Bok-Cho',
                   quantity: '100',
                   crop_variety: 'Banana Split',
@@ -185,8 +187,8 @@ RSpec.describe MetrcService::Plant::Start do
             {
               id: 3000,
               relationships: {
-                batch: { data: { id: 2002 } },
-                facility: { data: { id: 1568 } }
+                batch: { data: { id: batch_id } },
+                facility: { data: { id: facility_id } }
               },
               attributes: {
                 options: {
@@ -247,16 +249,16 @@ RSpec.describe MetrcService::Plant::Start do
           subject { described_class.new(ctx, integration) }
 
           before do
-            stub_request(:get, 'https://portal.artemisag.com/api/v3/facilities/1568')
-              .to_return(body: { data: { id: '1568', type: 'facilities', attributes: { id: 1568, name: 'Rare Dankness' } } }.to_json)
+            stub_request(:get, "https://portal.artemisag.com/api/v3/facilities/#{facility_id}")
+              .to_return(body: { data: { id: facility_id, type: 'facilities', attributes: { id: facility_id, name: 'Rare Dankness' } } }.to_json)
 
-            stub_request(:get, 'https://portal.artemisag.com/api/v3/facilities/1568/batches/2002?include=zone,zone.sub_stage,barcodes,custom_data,seeding_unit,harvest_unit,sub_zone,custom_data.custom_field')
+            stub_request(:get, "https://portal.artemisag.com/api/v3/facilities/#{facility_id}/batches/#{batch_id}?include=zone,zone.sub_stage,barcodes,custom_data,seeding_unit,harvest_unit,sub_zone,custom_data.custom_field")
               .to_return(body: {
                 data: {
-                  id: '2002',
+                  id: batch_id,
                   type: 'batches',
                   attributes: {
-                    id: 2002,
+                    id: batch_id,
                     arbitrary_id: 'Jun19-Bok-Cho',
                     quantity: '100',
                     crop_variety: 'Banana Split',
@@ -319,7 +321,7 @@ RSpec.describe MetrcService::Plant::Start do
                     relationships: {
                       crop_batch: {
                         data: {
-                          id: '2002',
+                          id: batch_id,
                           type: 'crop_batches'
                         }
                       }
@@ -377,16 +379,16 @@ RSpec.describe MetrcService::Plant::Start do
           subject { described_class.new(ctx, integration) }
 
           before do
-            stub_request(:get, 'https://portal.artemisag.com/api/v3/facilities/1568')
-              .to_return(body: { data: { id: '1568', type: 'facilities', attributes: { id: 1568, name: 'Rare Dankness' } } }.to_json)
+            stub_request(:get, "https://portal.artemisag.com/api/v3/facilities/#{facility_id}")
+              .to_return(body: { data: { id: facility_id, type: 'facilities', attributes: { id: facility_id, name: 'Rare Dankness' } } }.to_json)
 
-            stub_request(:get, 'https://portal.artemisag.com/api/v3/facilities/1568/batches/2002?include=zone,zone.sub_stage,barcodes,custom_data,seeding_unit,harvest_unit,sub_zone,custom_data.custom_field')
+            stub_request(:get, "https://portal.artemisag.com/api/v3/facilities/#{facility_id}/batches/#{batch_id}?include=zone,zone.sub_stage,barcodes,custom_data,seeding_unit,harvest_unit,sub_zone,custom_data.custom_field")
               .to_return(body: {
                 data: {
-                  id: '2002',
+                  id: batch_id,
                   type: 'batches',
                   attributes: {
-                    id: 2002,
+                    id: batch_id,
                     arbitrary_id: 'Jun19-Bok-Cho',
                     quantity: '100',
                     crop_variety: 'Banana Split',
@@ -456,7 +458,7 @@ RSpec.describe MetrcService::Plant::Start do
                       },
                       crop_batch: {
                         data: {
-                          id: '2002',
+                          id: batch_id,
                           type: 'crop_batches'
                         }
                       }
@@ -495,6 +497,7 @@ RSpec.describe MetrcService::Plant::Start do
       context 'when planting is teens' do
         let(:now) { Time.zone.now.strftime('%Y-%m-%d') }
         let(:transaction) { create(:transaction, :unsuccessful, type: :start_batch_from_package) }
+        let(:batch_id) { 96182 }
         let(:expected_payload) do
           [{
             PackageLabel: 'Latiff',
@@ -513,17 +516,22 @@ RSpec.describe MetrcService::Plant::Start do
         end
 
         before do
-          stub_request(:get, 'https://portal.artemisag.com/api/v3/facilities/1568')
-            .to_return(body: { data: { id: '1568', type: 'facilities', attributes: { id: 1568, name: 'Rare Dankness' } } }.to_json)
+          stub_request(:get, "https://portal.artemisag.com/api/v3/facilities/#{facility_id}")
+            .to_return(body: { data: { id: facility_id, type: 'facilities', attributes: { id: facility_id, name: 'Rare Dankness' } } }.to_json)
 
-          stub_request(:get, 'https://portal.artemisag.com/api/v3/facilities/1568/batches/2002?include=zone,zone.sub_stage,barcodes,custom_data,seeding_unit,harvest_unit,sub_zone,custom_data.custom_field')
+          stub_request(:get, "https://portal.artemisag.com/api/v3/facilities/#{facility_id}/batches/#{batch_id}?include=zone,zone.sub_stage,barcodes,custom_data,seeding_unit,harvest_unit,sub_zone,custom_data.custom_field")
             .to_return(body: load_response_json('api/seed/batch-96182'))
 
           stub_request(:post, 'https://sandbox-api-ca.metrc.com/packages/v1/create/plantings?licenseNumber=LIC-0001')
             .with(body: expected_payload.to_json)
             .to_return(status: 200, body: '', headers: {})
 
-          stub_request(:get, "#{ENV['ARTEMIS_BASE_URI']}/api/v3/facilities/1568/completions/3000?include=action_result,crop_batch_state.seeding_unit,crop_batch_state.zone.sub_stage")
+          stub_request(:get, "#{ENV['ARTEMIS_BASE_URI']}/api/v3/facilities/#{facility_id}/completions?filter[crop_batch_ids][]=#{batch_id}")
+            .to_return(body: { data: [
+              JSON.parse(load_response_json('api/completions/3000'))['data']
+            ] }.to_json)
+
+          stub_request(:get, "#{ENV['ARTEMIS_BASE_URI']}/api/v3/facilities/#{facility_id}/completions/3000?include=action_result,crop_batch_state.seeding_unit,crop_batch_state.zone.sub_stage")
             .to_return(body: load_response_json('api/completions/3000'))
 
           stub_request(:post, 'https://sandbox-api-ca.metrc.com/plantbatches/v1/changegrowthphase?licenseNumber=LIC-0001')
@@ -538,7 +546,7 @@ RSpec.describe MetrcService::Plant::Start do
             }].to_json)
             .to_return(status: 200, body: '', headers: {})
 
-          stub_request(:get, 'https://portal.artemisag.com/api/v3/facilities/1568/completions?filter%5Baction_type%5D=generate&filter%5Bparent_id%5D=3000')
+          stub_request(:get, "https://portal.artemisag.com/api/v3/facilities/#{facility_id}/completions?filter%5Baction_type%5D=generate&filter%5Bparent_id%5D=3000")
             .to_return(status: 204, body: '', headers: {})
         end
 
@@ -560,16 +568,16 @@ RSpec.describe MetrcService::Plant::Start do
           let(:now) { Time.zone.now.strftime('%Y-%m-%d') }
 
           before do
-            stub_request(:get, 'https://portal.artemisag.com/api/v3/facilities/1568')
-              .to_return(body: { data: { id: '1568', type: 'facilities', attributes: { id: 1568, name: 'Rare Dankness' } } }.to_json)
+            stub_request(:get, "https://portal.artemisag.com/api/v3/facilities/#{facility_id}")
+              .to_return(body: { data: { id: facility_id, type: 'facilities', attributes: { id: facility_id, name: 'Rare Dankness' } } }.to_json)
 
-            stub_request(:get, 'https://portal.artemisag.com/api/v3/facilities/1568/batches/2002?include=zone,zone.sub_stage,barcodes,custom_data,seeding_unit,harvest_unit,sub_zone,custom_data.custom_field')
+            stub_request(:get, "https://portal.artemisag.com/api/v3/facilities/#{facility_id}/batches/#{batch_id}?include=zone,zone.sub_stage,barcodes,custom_data,seeding_unit,harvest_unit,sub_zone,custom_data.custom_field")
               .to_return(body: {
                 data: {
-                  id: '2002',
+                  id: batch_id,
                   type: 'batches',
                   attributes: {
-                    id: 2002,
+                    id: batch_id,
                     arbitrary_id: 'Jun19-Bok-Cho',
                     quantity: '100',
                     crop_variety: 'Banana Split',
@@ -639,7 +647,7 @@ RSpec.describe MetrcService::Plant::Start do
                       },
                       crop_batch: {
                         data: {
-                          id: '2002',
+                          id: batch_id,
                           type: 'crop_batches'
                         }
                       }
@@ -703,17 +711,17 @@ RSpec.describe MetrcService::Plant::Start do
           end
 
           before do
-            stub_request(:get, 'https://portal.artemisag.com/api/v3/facilities/1568')
-              .to_return(body: { data: { id: '1568', type: 'facilities', attributes: { id: 1568, name: 'Rare Dankness' } } }.to_json)
+            stub_request(:get, "https://portal.artemisag.com/api/v3/facilities/#{facility_id}")
+              .to_return(body: { data: { id: facility_id, type: 'facilities', attributes: { id: facility_id, name: 'Rare Dankness' } } }.to_json)
 
-            stub_request(:get, 'https://portal.artemisag.com/api/v3/facilities/1568/batches/2002?include=zone,zone.sub_stage,barcodes,custom_data,seeding_unit,harvest_unit,sub_zone,custom_data.custom_field')
+            stub_request(:get, "https://portal.artemisag.com/api/v3/facilities/#{facility_id}/batches/#{batch_id}?include=zone,zone.sub_stage,barcodes,custom_data,seeding_unit,harvest_unit,sub_zone,custom_data.custom_field")
               .to_return(body: load_response_json('api/seed/batch-96183'))
 
             stub_request(:post, 'https://sandbox-api-ca.metrc.com/plants/v1/create/plantings?licenseNumber=LIC-0001')
               .with(body: expected_payload.to_json)
               .to_return(status: 200, body: '', headers: {})
 
-            stub_request(:get, 'https://portal.artemisag.com/api/v3/facilities/1568/completions?filter%5Baction_type%5D=generate&filter%5Bparent_id%5D=3000')
+            stub_request(:get, "https://portal.artemisag.com/api/v3/facilities/#{facility_id}/completions?filter%5Baction_type%5D=generate&filter%5Bparent_id%5D=3000")
               .to_return(status: 204, body: '', headers: {})
           end
 

--- a/spec/support/data/api/completions/2999-veg-move.json
+++ b/spec/support/data/api/completions/2999-veg-move.json
@@ -1,0 +1,447 @@
+{
+  "data": {
+    "id": "2999",
+    "type": "completions",
+    "attributes": {
+      "id": 2999,
+      "status": "active",
+      "user_id": 1772,
+      "content": null,
+      "start_time": "2020-03-20T07:00:00.000Z",
+      "end_time": "2020-03-20T07:00:00.000Z",
+      "occurrence": 0,
+      "action_type": "move",
+      "parent_id": 762427,
+      "context": {
+        "source_batches": null
+      },
+      "options": {
+        "zone_id": 7249,
+        "quantity": 100,
+        "sub_zone_id": null,
+        "arbitrary_id": "Mar30-Lav-Cak-M0102",
+        "crop_variety_id": 19278,
+        "seeding_unit_id": 3591,
+        "zone_name": "Mothers [Veg]"
+      }
+    },
+    "relationships": {
+      "action_result": {
+        "data": {
+          "id": null,
+          "type": null
+        }
+      },
+      "batch": {
+        "data": {
+          "id": "105681",
+          "type": "batches"
+        }
+      },
+      "facility": {
+        "data": {
+          "id": 1626,
+          "type": "facilities"
+        }
+      },
+      "user": {
+        "data": {
+          "id": 1772,
+          "type": "users"
+        }
+      },
+      "crop_batch_state": {
+        "data": {
+          "type": "crop_batch_states",
+          "id": "425818"
+        }
+      }
+    }
+  },
+  "included": [
+    {
+      "id": "425818",
+      "type": "crop_batch_states",
+      "attributes": {
+        "harvest_quantity": null,
+        "id": 425818,
+        "quantity": 100
+      },
+      "relationships": {
+        "crop_batch": {
+          "data": {
+            "id": "105681",
+            "type": "crop_batches"
+          }
+        },
+        "completion": {
+          "data": {
+            "id": "762428",
+            "type": "completions"
+          }
+        },
+        "zone": {
+          "data": {
+            "id": "7249",
+            "type": "zones"
+          }
+        },
+        "sub_zone": {
+          "data": {
+            "id": "",
+            "type": "sub_zones"
+          }
+        },
+        "seeding_unit": {
+          "data": {
+            "id": "3591",
+            "type": "seeding_units"
+          }
+        },
+        "harvest_unit": {
+          "data": {
+            "id": "",
+            "type": "harvest_units"
+          }
+        }
+      }
+    },
+    {
+      "id": "3591",
+      "type": "seeding_units",
+      "attributes": {
+        "id": 3591,
+        "name": "plants",
+        "secondary_display_active": false,
+        "secondary_display_capacity": null,
+        "item_tracking_method": "none"
+      }
+    },
+    {
+      "id": "7094",
+      "type": "zones",
+      "attributes": {
+        "id": 7094,
+        "facility_id": 1634,
+        "name": "Zone 1",
+        "slug": "zone-1",
+        "zone_type": "generic",
+        "created_at": "2020-03-24T04:13:48.032Z",
+        "updated_at": "2020-07-13T20:41:30.798Z",
+        "status": "active",
+        "position": null,
+        "size": 0,
+        "seeding_unit": {
+          "id": 3601,
+          "name": "Plant (barcoded)",
+          "zones": [
+            {
+              "id": 7098,
+              "slug": "drycure--dry-",
+              "name": "Dry/Cure [Dry]",
+              "seeding_unit_id": 3601,
+              "zone_type": "generic",
+              "sub_zones": []
+            },
+            {
+              "id": 7094,
+              "slug": "zone-1",
+              "name": "Zone 1",
+              "seeding_unit_id": 3601,
+              "zone_type": "generic",
+              "sub_zones": [
+                {
+                  "id": 12232,
+                  "name": "Table 1",
+                  "slug": "table-1-48"
+                },
+                {
+                  "id": 12233,
+                  "name": "Table 2",
+                  "slug": "table-2-47"
+                },
+                {
+                  "id": 12234,
+                  "name": "Table 3",
+                  "slug": "table-3-41"
+                }
+              ]
+            },
+            {
+              "id": 7202,
+              "slug": "zone-2",
+              "name": "Zone 2",
+              "seeding_unit_id": 3601,
+              "zone_type": "generic",
+              "sub_zones": [
+                {
+                  "id": 12235,
+                  "name": "Table 4",
+                  "slug": "table-4-40"
+                },
+                {
+                  "id": 12236,
+                  "name": "Table 5",
+                  "slug": "table-5-40"
+                },
+                {
+                  "id": 12237,
+                  "name": "Table 6",
+                  "slug": "table-6-40"
+                }
+              ]
+            },
+            {
+              "id": 7095,
+              "slug": "zone-3",
+              "name": "Zone 3",
+              "seeding_unit_id": 3601,
+              "zone_type": "generic",
+              "sub_zones": [
+                {
+                  "id": 12238,
+                  "name": "Table 7",
+                  "slug": "table-7-39"
+                },
+                {
+                  "id": 12239,
+                  "name": "Table 8",
+                  "slug": "table-8-5"
+                },
+                {
+                  "id": 12240,
+                  "name": "Table 9",
+                  "slug": "table-9-1"
+                },
+                {
+                  "id": 12241,
+                  "name": "Table 10",
+                  "slug": "table-10-1"
+                }
+              ]
+            },
+            {
+              "id": 7203,
+              "slug": "zone-4",
+              "name": "Zone 4",
+              "seeding_unit_id": 3601,
+              "zone_type": "generic",
+              "sub_zones": [
+                {
+                  "id": 12242,
+                  "name": "Table 11",
+                  "slug": "table-11-1"
+                },
+                {
+                  "id": 12243,
+                  "name": "Table 12",
+                  "slug": "table-12-1"
+                },
+                {
+                  "id": 12244,
+                  "name": "Table 13",
+                  "slug": "table-13-1"
+                },
+                {
+                  "id": 12245,
+                  "name": "Table 14",
+                  "slug": "table-14-1"
+                }
+              ]
+            },
+            {
+              "id": 7096,
+              "slug": "zone-5",
+              "name": "Zone 5",
+              "seeding_unit_id": 3601,
+              "zone_type": "generic",
+              "sub_zones": [
+                {
+                  "id": 12246,
+                  "name": "Table 15",
+                  "slug": "table-15-1"
+                },
+                {
+                  "id": 12247,
+                  "name": "Table 16",
+                  "slug": "table-16-1"
+                },
+                {
+                  "id": 12248,
+                  "name": "Table 17",
+                  "slug": "table-17"
+                }
+              ]
+            },
+            {
+              "id": 7204,
+              "slug": "zone-6",
+              "name": "Zone 6",
+              "seeding_unit_id": 3601,
+              "zone_type": "generic",
+              "sub_zones": [
+                {
+                  "id": 12249,
+                  "name": "Table 18",
+                  "slug": "table-18-1"
+                },
+                {
+                  "id": 12250,
+                  "name": "Table 19",
+                  "slug": "table-19"
+                },
+                {
+                  "id": 12251,
+                  "name": "Table 20",
+                  "slug": "table-20"
+                }
+              ]
+            },
+            {
+              "id": 7097,
+              "slug": "zone-7",
+              "name": "Zone 7",
+              "seeding_unit_id": 3601,
+              "zone_type": "generic",
+              "sub_zones": [
+                {
+                  "id": 12252,
+                  "name": "Table 21",
+                  "slug": "table-21"
+                },
+                {
+                  "id": 12253,
+                  "name": "Table 22",
+                  "slug": "table-22"
+                },
+                {
+                  "id": 12254,
+                  "name": "Table 23",
+                  "slug": "table-23"
+                },
+                {
+                  "id": 12255,
+                  "name": "Table 24",
+                  "slug": "table-24"
+                },
+                {
+                  "id": 12256,
+                  "name": "Table 25",
+                  "slug": "table-25"
+                },
+                {
+                  "id": 12257,
+                  "name": "Table 26",
+                  "slug": "table-26"
+                },
+                {
+                  "id": 12258,
+                  "name": "Table 27",
+                  "slug": "table-27"
+                }
+              ]
+            },
+            {
+              "id": 7205,
+              "slug": "zone-8",
+              "name": "Zone 8",
+              "seeding_unit_id": 3601,
+              "zone_type": "generic",
+              "sub_zones": [
+                {
+                  "id": 12259,
+                  "name": "Table 28",
+                  "slug": "table-28"
+                },
+                {
+                  "id": 12260,
+                  "name": "Table 29",
+                  "slug": "table-29"
+                },
+                {
+                  "id": 12261,
+                  "name": "Table 30",
+                  "slug": "table-30"
+                },
+                {
+                  "id": 12262,
+                  "name": "Table 31",
+                  "slug": "table-31"
+                },
+                {
+                  "id": 12263,
+                  "name": "Table 32",
+                  "slug": "table-32"
+                },
+                {
+                  "id": 12264,
+                  "name": "Table 33",
+                  "slug": "table-33"
+                },
+                {
+                  "id": 12265,
+                  "name": "Table 34",
+                  "slug": "table-34"
+                }
+              ]
+            }
+          ],
+          "secondary_display_active": false,
+          "secondary_display_capacity": null
+        },
+        "seeding_unit_capacity": 1476,
+        "system": "None"
+      },
+      "relationships": {
+        "sub_zones": {
+          "meta": {
+            "included": false
+          }
+        },
+        "stage": {
+          "data": {
+            "id": "1068",
+            "type": "stages"
+          }
+        },
+        "sub_stage": {
+          "data": {
+            "id": "24",
+            "type": "sub_stages"
+          }
+        },
+        "seeding_unit": {
+          "data": {
+            "id": "3601",
+            "type": "seeding_units"
+          }
+        }
+      }
+    },
+    {
+      "id": "24",
+      "type": "sub_stages",
+      "attributes": {
+        "id": 24,
+        "name": "Vegetation",
+        "position": 1
+      },
+      "relationships": {
+        "stage": {
+          "data": {
+            "id": "1068",
+            "type": "stages"
+          }
+        },
+        "zones": {
+          "meta": {
+            "included": false
+          }
+        }
+      }
+    }
+  ],
+  "jsonapi": {
+    "version": "1.0"
+  }
+}

--- a/spec/support/data/api/completions/3000-veg-move.json
+++ b/spec/support/data/api/completions/3000-veg-move.json
@@ -1,0 +1,448 @@
+{
+  "data": {
+    "id": "3000",
+    "type": "completions",
+    "attributes": {
+      "id": 3000,
+      "status": "active",
+      "user_id": 1772,
+      "content": null,
+      "start_time": "2020-03-30T07:00:00.000Z",
+      "end_time": "2020-03-30T07:00:00.000Z",
+      "occurrence": 0,
+      "action_type": "move",
+      "parent_id": 762427,
+      "context": {
+        "source_batches": null
+      },
+      "options": {
+        "zone_id": 7249,
+        "quantity": 100,
+        "sub_zone_id": null,
+        "arbitrary_id": "Mar30-Lav-Cak-M0102",
+        "crop_variety_id": 19278,
+        "seeding_unit_id": 3591,
+        "zone_name": "Mothers [Veg]",
+        "item_ids": ["ABCDEF1234567890ABCDEF01"]
+      }
+    },
+    "relationships": {
+      "action_result": {
+        "data": {
+          "id": null,
+          "type": null
+        }
+      },
+      "batch": {
+        "data": {
+          "id": "105681",
+          "type": "batches"
+        }
+      },
+      "facility": {
+        "data": {
+          "id": 1626,
+          "type": "facilities"
+        }
+      },
+      "user": {
+        "data": {
+          "id": 1772,
+          "type": "users"
+        }
+      },
+      "crop_batch_state": {
+        "data": {
+          "type": "crop_batch_states",
+          "id": "425818"
+        }
+      }
+    }
+  },
+  "included": [
+    {
+      "id": "425818",
+      "type": "crop_batch_states",
+      "attributes": {
+        "harvest_quantity": null,
+        "id": 425818,
+        "quantity": 100
+      },
+      "relationships": {
+        "crop_batch": {
+          "data": {
+            "id": "105681",
+            "type": "crop_batches"
+          }
+        },
+        "completion": {
+          "data": {
+            "id": "3000",
+            "type": "completions"
+          }
+        },
+        "zone": {
+          "data": {
+            "id": "7249",
+            "type": "zones"
+          }
+        },
+        "sub_zone": {
+          "data": {
+            "id": "",
+            "type": "sub_zones"
+          }
+        },
+        "seeding_unit": {
+          "data": {
+            "id": "3591",
+            "type": "seeding_units"
+          }
+        },
+        "harvest_unit": {
+          "data": {
+            "id": "",
+            "type": "harvest_units"
+          }
+        }
+      }
+    },
+    {
+      "id": "3591",
+      "type": "seeding_units",
+      "attributes": {
+        "id": 3591,
+        "name": "plants",
+        "secondary_display_active": false,
+        "secondary_display_capacity": null,
+        "item_tracking_method": "none"
+      }
+    },
+    {
+      "id": "7094",
+      "type": "zones",
+      "attributes": {
+        "id": 7094,
+        "facility_id": 1634,
+        "name": "Zone 1",
+        "slug": "zone-1",
+        "zone_type": "generic",
+        "created_at": "2020-03-24T04:13:48.032Z",
+        "updated_at": "2020-07-13T20:41:30.798Z",
+        "status": "active",
+        "position": null,
+        "size": 0,
+        "seeding_unit": {
+          "id": 3601,
+          "name": "Plant (barcoded)",
+          "zones": [
+            {
+              "id": 7098,
+              "slug": "drycure--dry-",
+              "name": "Dry/Cure [Dry]",
+              "seeding_unit_id": 3601,
+              "zone_type": "generic",
+              "sub_zones": []
+            },
+            {
+              "id": 7094,
+              "slug": "zone-1",
+              "name": "Zone 1",
+              "seeding_unit_id": 3601,
+              "zone_type": "generic",
+              "sub_zones": [
+                {
+                  "id": 12232,
+                  "name": "Table 1",
+                  "slug": "table-1-48"
+                },
+                {
+                  "id": 12233,
+                  "name": "Table 2",
+                  "slug": "table-2-47"
+                },
+                {
+                  "id": 12234,
+                  "name": "Table 3",
+                  "slug": "table-3-41"
+                }
+              ]
+            },
+            {
+              "id": 7202,
+              "slug": "zone-2",
+              "name": "Zone 2",
+              "seeding_unit_id": 3601,
+              "zone_type": "generic",
+              "sub_zones": [
+                {
+                  "id": 12235,
+                  "name": "Table 4",
+                  "slug": "table-4-40"
+                },
+                {
+                  "id": 12236,
+                  "name": "Table 5",
+                  "slug": "table-5-40"
+                },
+                {
+                  "id": 12237,
+                  "name": "Table 6",
+                  "slug": "table-6-40"
+                }
+              ]
+            },
+            {
+              "id": 7095,
+              "slug": "zone-3",
+              "name": "Zone 3",
+              "seeding_unit_id": 3601,
+              "zone_type": "generic",
+              "sub_zones": [
+                {
+                  "id": 12238,
+                  "name": "Table 7",
+                  "slug": "table-7-39"
+                },
+                {
+                  "id": 12239,
+                  "name": "Table 8",
+                  "slug": "table-8-5"
+                },
+                {
+                  "id": 12240,
+                  "name": "Table 9",
+                  "slug": "table-9-1"
+                },
+                {
+                  "id": 12241,
+                  "name": "Table 10",
+                  "slug": "table-10-1"
+                }
+              ]
+            },
+            {
+              "id": 7203,
+              "slug": "zone-4",
+              "name": "Zone 4",
+              "seeding_unit_id": 3601,
+              "zone_type": "generic",
+              "sub_zones": [
+                {
+                  "id": 12242,
+                  "name": "Table 11",
+                  "slug": "table-11-1"
+                },
+                {
+                  "id": 12243,
+                  "name": "Table 12",
+                  "slug": "table-12-1"
+                },
+                {
+                  "id": 12244,
+                  "name": "Table 13",
+                  "slug": "table-13-1"
+                },
+                {
+                  "id": 12245,
+                  "name": "Table 14",
+                  "slug": "table-14-1"
+                }
+              ]
+            },
+            {
+              "id": 7096,
+              "slug": "zone-5",
+              "name": "Zone 5",
+              "seeding_unit_id": 3601,
+              "zone_type": "generic",
+              "sub_zones": [
+                {
+                  "id": 12246,
+                  "name": "Table 15",
+                  "slug": "table-15-1"
+                },
+                {
+                  "id": 12247,
+                  "name": "Table 16",
+                  "slug": "table-16-1"
+                },
+                {
+                  "id": 12248,
+                  "name": "Table 17",
+                  "slug": "table-17"
+                }
+              ]
+            },
+            {
+              "id": 7204,
+              "slug": "zone-6",
+              "name": "Zone 6",
+              "seeding_unit_id": 3601,
+              "zone_type": "generic",
+              "sub_zones": [
+                {
+                  "id": 12249,
+                  "name": "Table 18",
+                  "slug": "table-18-1"
+                },
+                {
+                  "id": 12250,
+                  "name": "Table 19",
+                  "slug": "table-19"
+                },
+                {
+                  "id": 12251,
+                  "name": "Table 20",
+                  "slug": "table-20"
+                }
+              ]
+            },
+            {
+              "id": 7097,
+              "slug": "zone-7",
+              "name": "Zone 7",
+              "seeding_unit_id": 3601,
+              "zone_type": "generic",
+              "sub_zones": [
+                {
+                  "id": 12252,
+                  "name": "Table 21",
+                  "slug": "table-21"
+                },
+                {
+                  "id": 12253,
+                  "name": "Table 22",
+                  "slug": "table-22"
+                },
+                {
+                  "id": 12254,
+                  "name": "Table 23",
+                  "slug": "table-23"
+                },
+                {
+                  "id": 12255,
+                  "name": "Table 24",
+                  "slug": "table-24"
+                },
+                {
+                  "id": 12256,
+                  "name": "Table 25",
+                  "slug": "table-25"
+                },
+                {
+                  "id": 12257,
+                  "name": "Table 26",
+                  "slug": "table-26"
+                },
+                {
+                  "id": 12258,
+                  "name": "Table 27",
+                  "slug": "table-27"
+                }
+              ]
+            },
+            {
+              "id": 7205,
+              "slug": "zone-8",
+              "name": "Zone 8",
+              "seeding_unit_id": 3601,
+              "zone_type": "generic",
+              "sub_zones": [
+                {
+                  "id": 12259,
+                  "name": "Table 28",
+                  "slug": "table-28"
+                },
+                {
+                  "id": 12260,
+                  "name": "Table 29",
+                  "slug": "table-29"
+                },
+                {
+                  "id": 12261,
+                  "name": "Table 30",
+                  "slug": "table-30"
+                },
+                {
+                  "id": 12262,
+                  "name": "Table 31",
+                  "slug": "table-31"
+                },
+                {
+                  "id": 12263,
+                  "name": "Table 32",
+                  "slug": "table-32"
+                },
+                {
+                  "id": 12264,
+                  "name": "Table 33",
+                  "slug": "table-33"
+                },
+                {
+                  "id": 12265,
+                  "name": "Table 34",
+                  "slug": "table-34"
+                }
+              ]
+            }
+          ],
+          "secondary_display_active": false,
+          "secondary_display_capacity": null
+        },
+        "seeding_unit_capacity": 1476,
+        "system": "None"
+      },
+      "relationships": {
+        "sub_zones": {
+          "meta": {
+            "included": false
+          }
+        },
+        "stage": {
+          "data": {
+            "id": "1068",
+            "type": "stages"
+          }
+        },
+        "sub_stage": {
+          "data": {
+            "id": "24",
+            "type": "sub_stages"
+          }
+        },
+        "seeding_unit": {
+          "data": {
+            "id": "3601",
+            "type": "seeding_units"
+          }
+        }
+      }
+    },
+    {
+      "id": "24",
+      "type": "sub_stages",
+      "attributes": {
+        "id": 24,
+        "name": "Vegetation",
+        "position": 1
+      },
+      "relationships": {
+        "stage": {
+          "data": {
+            "id": "1068",
+            "type": "stages"
+          }
+        },
+        "zones": {
+          "meta": {
+            "included": false
+          }
+        }
+      }
+    }
+  ],
+  "jsonapi": {
+    "version": "1.0"
+  }
+}

--- a/spec/support/data/api/completions/3000.json
+++ b/spec/support/data/api/completions/3000.json
@@ -1,9 +1,9 @@
 {
   "data": {
-    "id": "762428",
+    "id": "3000",
     "type": "completions",
     "attributes": {
-      "id": 762428,
+      "id": 3000,
       "status": "active",
       "user_id": 1772,
       "content": null,
@@ -76,7 +76,7 @@
         },
         "completion": {
           "data": {
-            "id": "762428",
+            "id": "3000",
             "type": "completions"
           }
         },

--- a/spec/support/data/api/completions/3999-flower-move.json
+++ b/spec/support/data/api/completions/3999-flower-move.json
@@ -1,0 +1,447 @@
+{
+  "data": {
+    "id": "3999",
+    "type": "completions",
+    "attributes": {
+      "id": 3999,
+      "status": "active",
+      "user_id": 1772,
+      "content": null,
+      "start_time": "2020-03-20T07:00:00.000Z",
+      "end_time": "2020-03-20T07:00:00.000Z",
+      "occurrence": 0,
+      "action_type": "move",
+      "parent_id": 762427,
+      "context": {
+        "source_batches": null
+      },
+      "options": {
+        "zone_id": 7249,
+        "quantity": 100,
+        "sub_zone_id": null,
+        "arbitrary_id": "Mar30-Lav-Cak-M0102",
+        "crop_variety_id": 19278,
+        "seeding_unit_id": 3591,
+        "zone_name": "Mothers [Veg]"
+      }
+    },
+    "relationships": {
+      "action_result": {
+        "data": {
+          "id": null,
+          "type": null
+        }
+      },
+      "batch": {
+        "data": {
+          "id": "105681",
+          "type": "batches"
+        }
+      },
+      "facility": {
+        "data": {
+          "id": 1626,
+          "type": "facilities"
+        }
+      },
+      "user": {
+        "data": {
+          "id": 1772,
+          "type": "users"
+        }
+      },
+      "crop_batch_state": {
+        "data": {
+          "type": "crop_batch_states",
+          "id": "425818"
+        }
+      }
+    }
+  },
+  "included": [
+    {
+      "id": "425818",
+      "type": "crop_batch_states",
+      "attributes": {
+        "harvest_quantity": null,
+        "id": 425818,
+        "quantity": 100
+      },
+      "relationships": {
+        "crop_batch": {
+          "data": {
+            "id": "105681",
+            "type": "crop_batches"
+          }
+        },
+        "completion": {
+          "data": {
+            "id": "762428",
+            "type": "completions"
+          }
+        },
+        "zone": {
+          "data": {
+            "id": "7249",
+            "type": "zones"
+          }
+        },
+        "sub_zone": {
+          "data": {
+            "id": "",
+            "type": "sub_zones"
+          }
+        },
+        "seeding_unit": {
+          "data": {
+            "id": "3591",
+            "type": "seeding_units"
+          }
+        },
+        "harvest_unit": {
+          "data": {
+            "id": "",
+            "type": "harvest_units"
+          }
+        }
+      }
+    },
+    {
+      "id": "3591",
+      "type": "seeding_units",
+      "attributes": {
+        "id": 3591,
+        "name": "plants",
+        "secondary_display_active": false,
+        "secondary_display_capacity": null,
+        "item_tracking_method": "none"
+      }
+    },
+    {
+      "id": "7094",
+      "type": "zones",
+      "attributes": {
+        "id": 7094,
+        "facility_id": 1634,
+        "name": "Zone 1",
+        "slug": "zone-1",
+        "zone_type": "generic",
+        "created_at": "2020-03-24T04:13:48.032Z",
+        "updated_at": "2020-07-13T20:41:30.798Z",
+        "status": "active",
+        "position": null,
+        "size": 0,
+        "seeding_unit": {
+          "id": 3601,
+          "name": "Plant (barcoded)",
+          "zones": [
+            {
+              "id": 7098,
+              "slug": "drycure--dry-",
+              "name": "Dry/Cure [Dry]",
+              "seeding_unit_id": 3601,
+              "zone_type": "generic",
+              "sub_zones": []
+            },
+            {
+              "id": 7094,
+              "slug": "zone-1",
+              "name": "Zone 1",
+              "seeding_unit_id": 3601,
+              "zone_type": "generic",
+              "sub_zones": [
+                {
+                  "id": 12232,
+                  "name": "Table 1",
+                  "slug": "table-1-48"
+                },
+                {
+                  "id": 12233,
+                  "name": "Table 2",
+                  "slug": "table-2-47"
+                },
+                {
+                  "id": 12234,
+                  "name": "Table 3",
+                  "slug": "table-3-41"
+                }
+              ]
+            },
+            {
+              "id": 7202,
+              "slug": "zone-2",
+              "name": "Zone 2",
+              "seeding_unit_id": 3601,
+              "zone_type": "generic",
+              "sub_zones": [
+                {
+                  "id": 12235,
+                  "name": "Table 4",
+                  "slug": "table-4-40"
+                },
+                {
+                  "id": 12236,
+                  "name": "Table 5",
+                  "slug": "table-5-40"
+                },
+                {
+                  "id": 12237,
+                  "name": "Table 6",
+                  "slug": "table-6-40"
+                }
+              ]
+            },
+            {
+              "id": 7095,
+              "slug": "zone-3",
+              "name": "Zone 3",
+              "seeding_unit_id": 3601,
+              "zone_type": "generic",
+              "sub_zones": [
+                {
+                  "id": 12238,
+                  "name": "Table 7",
+                  "slug": "table-7-39"
+                },
+                {
+                  "id": 12239,
+                  "name": "Table 8",
+                  "slug": "table-8-5"
+                },
+                {
+                  "id": 12240,
+                  "name": "Table 9",
+                  "slug": "table-9-1"
+                },
+                {
+                  "id": 12241,
+                  "name": "Table 10",
+                  "slug": "table-10-1"
+                }
+              ]
+            },
+            {
+              "id": 7203,
+              "slug": "zone-4",
+              "name": "Zone 4",
+              "seeding_unit_id": 3601,
+              "zone_type": "generic",
+              "sub_zones": [
+                {
+                  "id": 12242,
+                  "name": "Table 11",
+                  "slug": "table-11-1"
+                },
+                {
+                  "id": 12243,
+                  "name": "Table 12",
+                  "slug": "table-12-1"
+                },
+                {
+                  "id": 12244,
+                  "name": "Table 13",
+                  "slug": "table-13-1"
+                },
+                {
+                  "id": 12245,
+                  "name": "Table 14",
+                  "slug": "table-14-1"
+                }
+              ]
+            },
+            {
+              "id": 7096,
+              "slug": "zone-5",
+              "name": "Zone 5",
+              "seeding_unit_id": 3601,
+              "zone_type": "generic",
+              "sub_zones": [
+                {
+                  "id": 12246,
+                  "name": "Table 15",
+                  "slug": "table-15-1"
+                },
+                {
+                  "id": 12247,
+                  "name": "Table 16",
+                  "slug": "table-16-1"
+                },
+                {
+                  "id": 12248,
+                  "name": "Table 17",
+                  "slug": "table-17"
+                }
+              ]
+            },
+            {
+              "id": 7204,
+              "slug": "zone-6",
+              "name": "Zone 6",
+              "seeding_unit_id": 3601,
+              "zone_type": "generic",
+              "sub_zones": [
+                {
+                  "id": 12249,
+                  "name": "Table 18",
+                  "slug": "table-18-1"
+                },
+                {
+                  "id": 12250,
+                  "name": "Table 19",
+                  "slug": "table-19"
+                },
+                {
+                  "id": 12251,
+                  "name": "Table 20",
+                  "slug": "table-20"
+                }
+              ]
+            },
+            {
+              "id": 7097,
+              "slug": "zone-7",
+              "name": "Zone 7",
+              "seeding_unit_id": 3601,
+              "zone_type": "generic",
+              "sub_zones": [
+                {
+                  "id": 12252,
+                  "name": "Table 21",
+                  "slug": "table-21"
+                },
+                {
+                  "id": 12253,
+                  "name": "Table 22",
+                  "slug": "table-22"
+                },
+                {
+                  "id": 12254,
+                  "name": "Table 23",
+                  "slug": "table-23"
+                },
+                {
+                  "id": 12255,
+                  "name": "Table 24",
+                  "slug": "table-24"
+                },
+                {
+                  "id": 12256,
+                  "name": "Table 25",
+                  "slug": "table-25"
+                },
+                {
+                  "id": 12257,
+                  "name": "Table 26",
+                  "slug": "table-26"
+                },
+                {
+                  "id": 12258,
+                  "name": "Table 27",
+                  "slug": "table-27"
+                }
+              ]
+            },
+            {
+              "id": 7205,
+              "slug": "zone-8",
+              "name": "Zone 8",
+              "seeding_unit_id": 3601,
+              "zone_type": "generic",
+              "sub_zones": [
+                {
+                  "id": 12259,
+                  "name": "Table 28",
+                  "slug": "table-28"
+                },
+                {
+                  "id": 12260,
+                  "name": "Table 29",
+                  "slug": "table-29"
+                },
+                {
+                  "id": 12261,
+                  "name": "Table 30",
+                  "slug": "table-30"
+                },
+                {
+                  "id": 12262,
+                  "name": "Table 31",
+                  "slug": "table-31"
+                },
+                {
+                  "id": 12263,
+                  "name": "Table 32",
+                  "slug": "table-32"
+                },
+                {
+                  "id": 12264,
+                  "name": "Table 33",
+                  "slug": "table-33"
+                },
+                {
+                  "id": 12265,
+                  "name": "Table 34",
+                  "slug": "table-34"
+                }
+              ]
+            }
+          ],
+          "secondary_display_active": false,
+          "secondary_display_capacity": null
+        },
+        "seeding_unit_capacity": 1476,
+        "system": "None"
+      },
+      "relationships": {
+        "sub_zones": {
+          "meta": {
+            "included": false
+          }
+        },
+        "stage": {
+          "data": {
+            "id": "1068",
+            "type": "stages"
+          }
+        },
+        "sub_stage": {
+          "data": {
+            "id": "24",
+            "type": "sub_stages"
+          }
+        },
+        "seeding_unit": {
+          "data": {
+            "id": "3601",
+            "type": "seeding_units"
+          }
+        }
+      }
+    },
+    {
+      "id": "24",
+      "type": "sub_stages",
+      "attributes": {
+        "id": 24,
+        "name": "Flowering",
+        "position": 1
+      },
+      "relationships": {
+        "stage": {
+          "data": {
+            "id": "1068",
+            "type": "stages"
+          }
+        },
+        "zones": {
+          "meta": {
+            "included": false
+          }
+        }
+      }
+    }
+  ],
+  "jsonapi": {
+    "version": "1.0"
+  }
+}

--- a/spec/support/data/api/completions/4000-flower-move.json
+++ b/spec/support/data/api/completions/4000-flower-move.json
@@ -1,9 +1,9 @@
 {
   "data": {
-    "id": "762428",
+    "id": "4000",
     "type": "completions",
     "attributes": {
-      "id": 762428,
+      "id": 4000,
       "status": "active",
       "user_id": 1772,
       "content": null,
@@ -22,10 +22,8 @@
         "arbitrary_id": "Mar30-Lav-Cak-M0102",
         "crop_variety_id": 19278,
         "seeding_unit_id": 3591,
-        "zone_name": "Mothers [Veg]",
-        "item_ids": [
-          "ABCDEF1234567890ABCDEF01"
-        ]
+        "zone_name": "Mothers [Flowering]",
+        "item_ids": ["ABCDEF1234567890ABCDEF01"]
       }
     },
     "relationships": {
@@ -79,7 +77,7 @@
         },
         "completion": {
           "data": {
-            "id": "762428",
+            "id": "4000",
             "type": "completions"
           }
         },
@@ -426,7 +424,7 @@
       "type": "sub_stages",
       "attributes": {
         "id": 24,
-        "name": "Vegetation",
+        "name": "Flowering",
         "position": 1
       },
       "relationships": {

--- a/spec/support/data/api/completions/762428-curing-preprinted.json
+++ b/spec/support/data/api/completions/762428-curing-preprinted.json
@@ -16,13 +16,13 @@
         "source_batches": null
       },
       "options": {
-        "zone_id": 7249,
+        "zone_id": 7251,
         "quantity": 100,
         "sub_zone_id": null,
         "arbitrary_id": "Mar30-Lav-Cak-M0102",
         "crop_variety_id": 19278,
         "seeding_unit_id": 3591,
-        "zone_name": "Mothers [Flowering]"
+        "zone_name": "Cure Room"
       }
     },
     "relationships": {

--- a/spec/support/data/api/completions/762428-drying-preprinted.json
+++ b/spec/support/data/api/completions/762428-drying-preprinted.json
@@ -16,13 +16,13 @@
         "source_batches": null
       },
       "options": {
-        "zone_id": 7249,
+        "zone_id": 7250,
         "quantity": 100,
         "sub_zone_id": null,
         "arbitrary_id": "Mar30-Lav-Cak-M0102",
         "crop_variety_id": 19278,
         "seeding_unit_id": 3591,
-        "zone_name": "Mothers [Flowering]"
+        "zone_name": "Drying Room"
       }
     },
     "relationships": {

--- a/spec/support/data/api/completions/762428-flowering-preprinted.json
+++ b/spec/support/data/api/completions/762428-flowering-preprinted.json
@@ -7,10 +7,10 @@
       "status": "active",
       "user_id": 1772,
       "content": null,
-      "start_time": "2020-03-30T07:00:00.000Z",
-      "end_time": "2020-03-30T07:00:00.000Z",
+      "start_time": "2020-03-20T07:00:00.000Z",
+      "end_time": "2020-03-20T07:00:00.000Z",
       "occurrence": 0,
-      "action_type": "start",
+      "action_type": "move",
       "parent_id": 762427,
       "context": {
         "source_batches": null

--- a/spec/support/data/api/completions/762428-no-seeding.json
+++ b/spec/support/data/api/completions/762428-no-seeding.json
@@ -10,7 +10,7 @@
       "start_time": "2020-03-30T07:00:00.000Z",
       "end_time": "2020-03-30T07:00:00.000Z",
       "occurrence": 0,
-      "action_type": "start",
+      "action_type": "move",
       "parent_id": 762427,
       "context": {
         "source_batches": null

--- a/spec/support/data/api/completions/762429-clone-preprinted.json
+++ b/spec/support/data/api/completions/762429-clone-preprinted.json
@@ -10,7 +10,7 @@
       "start_time": "2020-03-30T07:00:00.000Z",
       "end_time": "2020-03-30T07:00:00.000Z",
       "occurrence": 0,
-      "action_type": "start",
+      "action_type": "move",
       "parent_id": 762427,
       "context": {
         "source_batches": null

--- a/spec/support/data/api/completions/762429-curing-preprinted.json
+++ b/spec/support/data/api/completions/762429-curing-preprinted.json
@@ -16,13 +16,13 @@
         "source_batches": null
       },
       "options": {
-        "zone_id": 7249,
+        "zone_id": 7251,
         "quantity": 100,
         "sub_zone_id": null,
         "arbitrary_id": "Mar30-Lav-Cak-M0102",
         "crop_variety_id": 19278,
         "seeding_unit_id": 3591,
-        "zone_name": "Mothers [Flowering]"
+        "zone_name": "Cure Room"
       }
     },
     "relationships": {

--- a/spec/support/data/api/completions/762429-curing-preprinted.json
+++ b/spec/support/data/api/completions/762429-curing-preprinted.json
@@ -10,7 +10,7 @@
       "start_time": "2020-03-30T07:00:00.000Z",
       "end_time": "2020-03-30T07:00:00.000Z",
       "occurrence": 0,
-      "action_type": "start",
+      "action_type": "move",
       "parent_id": 762427,
       "context": {
         "source_batches": null

--- a/spec/support/data/api/completions/762429-drying-preprinted.json
+++ b/spec/support/data/api/completions/762429-drying-preprinted.json
@@ -10,19 +10,19 @@
       "start_time": "2020-03-30T07:00:00.000Z",
       "end_time": "2020-03-30T07:00:00.000Z",
       "occurrence": 0,
-      "action_type": "start",
+      "action_type": "move",
       "parent_id": 762427,
       "context": {
         "source_batches": null
       },
       "options": {
-        "zone_id": 7249,
+        "zone_id": 7250,
         "quantity": 100,
         "sub_zone_id": null,
         "arbitrary_id": "Mar30-Lav-Cak-M0102",
         "crop_variety_id": 19278,
         "seeding_unit_id": 3591,
-        "zone_name": "Mothers [Flowering]"
+        "zone_name": "Drying Room"
       }
     },
     "relationships": {

--- a/spec/support/data/api/completions/762429-flowering-preprinted.json
+++ b/spec/support/data/api/completions/762429-flowering-preprinted.json
@@ -10,7 +10,7 @@
       "start_time": "2020-03-30T07:00:00.000Z",
       "end_time": "2020-03-30T07:00:00.000Z",
       "occurrence": 0,
-      "action_type": "start",
+      "action_type": "move",
       "parent_id": 762427,
       "context": {
         "source_batches": null

--- a/spec/support/data/api/completions/762429-no-seeding.json
+++ b/spec/support/data/api/completions/762429-no-seeding.json
@@ -10,7 +10,7 @@
       "start_time": "2020-03-30T07:00:00.000Z",
       "end_time": "2020-03-30T07:00:00.000Z",
       "occurrence": 0,
-      "action_type": "start",
+      "action_type": "move",
       "parent_id": 762427,
       "context": {
         "source_batches": null

--- a/spec/support/data/api/completions/762429-vegetative-preprinted.json
+++ b/spec/support/data/api/completions/762429-vegetative-preprinted.json
@@ -10,7 +10,7 @@
       "start_time": "2020-03-30T07:00:00.000Z",
       "end_time": "2020-03-30T07:00:00.000Z",
       "occurrence": 0,
-      "action_type": "start",
+      "action_type": "move",
       "parent_id": 762427,
       "context": {
         "source_batches": null


### PR DESCRIPTION
We were accessing the previous stage by searching existing transactions.
This causes an issue when we onboard new clients we do not have transactions populated for all of their completions. 
Instead, find previous move/starts by querying for batch.completions