### PR TITLE
Skipped transactions should not halt other transactions from being performed [Delivers: #176827231]

### DIFF
--- a/app/services/metrc_service/batch.rb
+++ b/app/services/metrc_service/batch.rb
@@ -21,13 +21,12 @@ module MetrcService
         }.with_indifferent_access
 
         arr << MetrcService.perform_action(ctx, @integration, @task)
-
         # halt if the last action failed
-        break arr unless arr.last&.success?
+        break arr unless arr.last&.success? || arr.last&.skipped?
       end
 
       # a stub tranasction to represent the state of the batched transactions
-      result = Transaction.new(success: transactions.all?(&:success?))
+      result = Transaction.new(success: transactions.all? { |t| t.success? || t.skipped? })
       @task.delete if result.success?
 
       result

--- a/spec/factories/transaction_factory.rb
+++ b/spec/factories/transaction_factory.rb
@@ -14,6 +14,10 @@ FactoryBot.define do
       success { true }
     end
 
+    trait :skipped do
+      skipped { true }
+    end
+
     trait :unsuccessful do
       success { false }
     end

--- a/spec/services/metrc_service/batch_spec.rb
+++ b/spec/services/metrc_service/batch_spec.rb
@@ -63,6 +63,7 @@ RSpec.describe MetrcService::Batch do
       include_context 'with synced data'
 
       let(:successful_transaction) { create(:transaction, :harvest, :successful) }
+      let(:skipped_transaction) { create(:transaction, :harvest, :skipped) }
 
       before do
         stub_request(:get, 'https://portal.artemisag.com/api/v3/facilities/1568')
@@ -101,7 +102,7 @@ RSpec.describe MetrcService::Batch do
 
         expect(MetrcService::Plant::Start)
           .to receive(:call)
-          .and_return(successful_transaction)
+          .and_return(skipped_transaction)
 
         expect(MetrcService::Plant::Move)
           .to receive(:call)


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/176827231

When I implemented skipped transactions, I did not take into account that a transaction had to have been marked as successful in order for the remaining batch transactions to be run. 

This pr checks if a transaction is successful or skipped to continue to execute the remaining transactions. It also adds skipped to the check for all transactions being successful in order to delete the Scheduler.