### PR TITLE
Update invalid PackageAdjustmentUnitOfMeasureName unit of measure [Delivers: 179184421]

### DIFF
--- a/app/services/metrc_service/plant/start.rb
+++ b/app/services/metrc_service/plant/start.rb
@@ -60,8 +60,8 @@ module MetrcService
 
         [{
           PackageLabel: label.value,
-          PackageAdjustmentAmount: 0,
-          PackageAdjustmentUnitOfMeasureName: 'Ounces',
+          PackageAdjustmentAmount: nil,
+          PackageAdjustmentUnitOfMeasureName: nil,
           PlantBatchName: batch_tag,
           PlantBatchType: 'Clone',
           PlantCount: quantity,

--- a/spec/services/metrc_service/plant/start_spec.rb
+++ b/spec/services/metrc_service/plant/start_spec.rb
@@ -153,13 +153,13 @@ RSpec.describe MetrcService::Plant::Start do
             zone = double(:zone, attributes: zone_attributes, name: 'Germination')
 
             double(:batch,
-                    zone: zone,
-                    quantity: '100',
-                    crop_variety: 'Banana Split',
-                    seeded_at: Time.zone.now,
-                    relationships: {
-                      'barcodes': { 'data': [{ 'id': '1A4FF0100000022000001010' }] }
-                    }.with_indifferent_access)
+                   zone: zone,
+                   quantity: '100',
+                   crop_variety: 'Banana Split',
+                   seeded_at: Time.zone.now,
+                   relationships: {
+                     'barcodes': { 'data': [{ 'id': '1A4FF0100000022000001010' }] }
+                   }.with_indifferent_access)
           end
 
           subject { described_class.new(ctx, integration) }
@@ -209,15 +209,15 @@ RSpec.describe MetrcService::Plant::Start do
             zone = double(:zone, attributes: zone_attributes, name: 'Germination')
 
             double(:batch,
-                    zone: zone,
-                    quantity: '100',
-                    crop_variety: 'Banana Split',
-                    seeded_at: Time.zone.now,
-                    relationships: {
-                      barcodes: {
-                        'data': [{ 'type': :barcodes, 'id': '1A4FF0100000022000001101' }]
-                      }
-                    }.with_indifferent_access)
+                   zone: zone,
+                   quantity: '100',
+                   crop_variety: 'Banana Split',
+                   seeded_at: Time.zone.now,
+                   relationships: {
+                     barcodes: {
+                       'data': [{ 'type': :barcodes, 'id': '1A4FF0100000022000001101' }]
+                     }
+                   }.with_indifferent_access)
           end
 
           subject { described_class.new(ctx, integration) }
@@ -362,8 +362,8 @@ RSpec.describe MetrcService::Plant::Start do
             [
               {
                 LocationName: nil,
-                PackageAdjustmentAmount: 0,
-                PackageAdjustmentUnitOfMeasureName: 'Ounces',
+                PackageAdjustmentAmount: nil,
+                PackageAdjustmentUnitOfMeasureName: nil,
                 PackageLabel: '1A4060300003779000013229',
                 PatientLicenseNumber: nil,
                 PlantBatchName: '1A406020000E4E9000003989',
@@ -500,8 +500,8 @@ RSpec.describe MetrcService::Plant::Start do
         let(:expected_payload) do
           [{
             PackageLabel: 'Latiff',
-            PackageAdjustmentAmount: 0,
-            PackageAdjustmentUnitOfMeasureName: 'Ounces',
+            PackageAdjustmentAmount: nil,
+            PackageAdjustmentUnitOfMeasureName: nil,
             PlantBatchName: '1A4060300003B01000000838',
             PlantBatchType: 'Clone',
             PlantCount: 100,


### PR DESCRIPTION
The documentation shows 'Ounces' but when we recently tried to post a planting we received this error 
https://api-ca.metrc.com/Documentation/#Packages.post_packages_v1_create_plantings.POST

```
The Unit of Measure "Ounces" is invalid. Valid values are: Each.
```

we are hardcoding a quantity of zero anyways so I changed these values to nil instead.
