### PR TITLE
Allow module_for_completion to be nil and not report an error [Delivers: 180105696]

### DIFF
--- a/app/services/base_service.rb
+++ b/app/services/base_service.rb
@@ -51,7 +51,7 @@ module BaseService
       @task = task
     end
 
-    delegate :run_mode, to: :module_for_completion
+    delegate :run_mode, to: :module_for_completion, allow_nil: true
 
     def perform_action
       if completion.status == 'removed'


### PR DESCRIPTION
[Pivotal story](https://www.pivotaltracker.com/story/show/180105696)

There are some completions that will get reported to cannapis but we don't want to report to metrc based on the seeding_unit they are using (bin, cuttings). These completions will not have a module_for_completion to run and will return nil. This pr keeps this case from being reported to bugsnag. 


#### To be completed by PR reviewer
- Testing - code has
  - [ ] thorough tests
  - [ ] surface level tests
  - [x] testing not needed
- Speed / Performance - application will be
  - [ ] probably faster
  - [ ] probably slower
  - [x] hard to tell based on the code or N/A
- Stability - code is
  - [ ] likely to introduce bugs / race conditions
  - [x] not likely to introduce bugs / race conditions
- Security - code is
  - [ ] likely to introduce security issues
  - [x] not likely introduce security issues
- "Smell Test" - documentation, readability, and cleanliness
  - [x] passes
  - [ ] fails
